### PR TITLE
add max-width for better readability

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -66,13 +66,14 @@
     display: block;
     min-height: 100%;
     width: 100%;
+    max-width: 47em;
     margin: 0 0 -50px;
     padding: 30px 20px 90px 30px;
     font-size: 16px;
     line-height: 170%;
     background: none;
     resize: none;
-    -moz-box-sizing: border-box; box-sizing: border-box;
+    box-sizing: border-box;
     font-family: inherit;
 }
 


### PR DESCRIPTION
Limits the width to a nicely readable roughly 70 characters per line. :)

Please review @nextcloud/designers @nextcloud/notes 