### PR TITLE
Minor changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Submitting issues
 
-If you have questions about how to install or use nextcloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
+If you have questions about how to install or use Nextcloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
 
 ### Short version
 
@@ -11,7 +11,7 @@ If you have questions about how to install or use nextcloud, please direct these
   - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
   - You can also filter by appending e. g. "state:open" to the search string.
   - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
-* This repository ([notes](https://github.com/nextcloud/notes/issues)) is *only* for issues within the nextcloud notes code.
+* This repository ([notes](https://github.com/nextcloud/notes/issues)) is *only* for issues within the Nextcloud notes code.
 * __SECURITY__: Report any potential security bug to security@nextcloud.com following our [security policy](https://nextcloud.com/security/) instead of filing an issue in our bug tracker
 * Report the issue using our [template][template], it includes all the information we need to track down the issue.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,13 @@ If you have questions about how to install or use nextcloud, please direct these
 
 Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
 
-[template]: https://raw.github.com/nextcloud/core/master/issue_template.md
+[template]: https://raw.github.com/nextcloud/server/master/issue_template.md
 [mailinglist]: https://mailman.owncloud.org/mailman/listinfo/owncloud
 [forum]: https://help.nextcloud.com/
 [irc]: https://webchat.freenode.net/?channels=nextcloud&uio=d4
 [irc-dev]: https://webchat.freenode.net/?channels=nextcloud-dev&uio=d4
 
 ### Contribute Code and translations
-Please check [core's contribution guidelines](https://github.com/nextcloud/core/blob/master/CONTRIBUTING.md) for further information about contributing code and translations.
+Please check [core's contribution guidelines](https://github.com/nextcloud/server/blob/master/CONTRIBUTING.md) for further information about contributing code and translations.
 
 For further development questions / discussions you can also join the [#nextcloud-dev][irc-dev] IRC channel.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Submitting issues
 
-If you have questions about how to install or use ownCloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
+If you have questions about how to install or use nextcloud, please direct these to the [mailing list][mailinglist] or our [forum][forum]. We are also available on [IRC][irc].
 
 ### Short version
 
@@ -11,19 +11,19 @@ If you have questions about how to install or use ownCloud, please direct these 
   - Go to one of the repositories, click "issues" and type any word in the top search/command bar.
   - You can also filter by appending e. g. "state:open" to the search string.
   - More info on [search syntax within github](https://help.github.com/articles/searching-issues)
-* This repository ([notes](https://github.com/owncloud/notes/issues)) is *only* for issues within the ownCloud notes code.
-* __SECURITY__: Report any potential security bug to security@owncloud.com following our [security policy](https://owncloud.org/security/) instead of filing an issue in our bug tracker
+* This repository ([notes](https://github.com/nextcloud/notes/issues)) is *only* for issues within the nextcloud notes code.
+* __SECURITY__: Report any potential security bug to security@nextcloud.com following our [security policy](https://nextcloud.com/security/) instead of filing an issue in our bug tracker
 * Report the issue using our [template][template], it includes all the information we need to track down the issue.
 
 Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
 
-[template]: https://raw.github.com/owncloud/core/master/issue_template.md
+[template]: https://raw.github.com/nextcloud/core/master/issue_template.md
 [mailinglist]: https://mailman.owncloud.org/mailman/listinfo/owncloud
-[forum]: https://forum.owncloud.org/
-[irc]: https://webchat.freenode.net/?channels=owncloud&uio=d4
-[irc-dev]: https://webchat.freenode.net/?channels=owncloud-dev&uio=d4
+[forum]: https://help.nextcloud.com/
+[irc]: https://webchat.freenode.net/?channels=nextcloud&uio=d4
+[irc-dev]: https://webchat.freenode.net/?channels=nextcloud-dev&uio=d4
 
 ### Contribute Code and translations
-Please check [core's contribution guidelines](https://github.com/owncloud/core/blob/master/CONTRIBUTING.md) for further information about contributing code and translations.
+Please check [core's contribution guidelines](https://github.com/nextcloud/core/blob/master/CONTRIBUTING.md) for further information about contributing code and translations.
 
-For further development questions / discussions you can also join the [#owncloud-dev][irc-dev] IRC channel.
+For further development questions / discussions you can also join the [#nextcloud-dev][irc-dev] IRC channel.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# nextcloud scaffolder tool
+# Nextcloud scaffolder tool
 #
 # Copyright (C) 2013 Bernhard Posselt, <nukewhale@gmail.com>
 #

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# ownCloud scaffolder tool
+# nextcloud scaffolder tool
 #
 # Copyright (C) 2013 Bernhard Posselt, <nukewhale@gmail.com>
 #

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/errors.php
+++ b/controller/errors.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/errors.php
+++ b/controller/errors.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/notesapicontroller.php
+++ b/controller/notesapicontroller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/notesapicontroller.php
+++ b/controller/notesapicontroller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/notescontroller.php
+++ b/controller/notescontroller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/notescontroller.php
+++ b/controller/notescontroller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/css/notes.css
+++ b/css/notes.css
@@ -9,7 +9,6 @@
 }
 
 #app-navigation #note-add span {
-    display: none;
     font-weight: bold;
     padding-left: 2px;
 }

--- a/db/note.php
+++ b/db/note.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/db/note.php
+++ b/db/note.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/js/bower.json
+++ b/js/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ownCloud notes",
+  "name": "Nextcloud notes",
   "version": "0.0.1",
   "dependencies": {
     "angular": "1.4.*",

--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -1,6 +1,6 @@
 
 /**
- * nextcloud - Notes app
+ * Nextcloud - Notes app
  *
  * @author Bernhard Posselt
  *

--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -1,6 +1,6 @@
 
 /**
- * ownCloud - Notes app
+ * nextcloud - Notes app
  *
  * @author Bernhard Posselt
  *

--- a/js/package.json
+++ b/js/package.json
@@ -3,12 +3,12 @@
   "description": "Notes app",
   "version": "0.0.1",
   "private": true,
-  "homepage": "https://github.com/owncloud/notes",
+  "homepage": "https://github.com/nextcloud/notes",
   "repository": {
     "type": "git",
-    "url": "git@github.com:owncloud/notes.git"
+    "url": "git@github.com:nextcloud/notes.git"
   },
-  "bugs": "https://github.com/owncloud/notes/issues",
+  "bugs": "https://github.com/nextcloud/notes/issues",
   "dependencies": {},
   "devDependencies": {
     "del": "^1.2.0",

--- a/service/notedoesnotexistexception.php
+++ b/service/notedoesnotexistexception.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/service/notedoesnotexistexception.php
+++ b/service/notedoesnotexistexception.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/integration/controller/NotesApiControllerTest.php
+++ b/tests/integration/controller/NotesApiControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/integration/controller/NotesApiControllerTest.php
+++ b/tests/integration/controller/NotesApiControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/integration/controller/NotesControllerTest.php
+++ b/tests/integration/controller/NotesControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/integration/controller/NotesControllerTest.php
+++ b/tests/integration/controller/NotesControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/controller/NotesApiControllerTest.php
+++ b/tests/unit/controller/NotesApiControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/controller/NotesApiControllerTest.php
+++ b/tests/unit/controller/NotesApiControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/controller/NotesControllerTest.php
+++ b/tests/unit/controller/NotesControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/controller/NotesControllerTest.php
+++ b/tests/unit/controller/NotesControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/controller/PageControllerTest.php
+++ b/tests/unit/controller/PageControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/controller/PageControllerTest.php
+++ b/tests/unit/controller/PageControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/db/NoteTest.php
+++ b/tests/unit/db/NoteTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/db/NoteTest.php
+++ b/tests/unit/db/NoteTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/service/NotesServiceTest.php
+++ b/tests/unit/service/NotesServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * nextcloud - Notes
+ * Nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.

--- a/tests/unit/service/NotesServiceTest.php
+++ b/tests/unit/service/NotesServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ownCloud - Notes
+ * nextcloud - Notes
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.


### PR DESCRIPTION
A couple of quick (and admittedly a bit dirty) changes to make things a bit clearer for the user and the developers:

1. Changed any instance of 'ownCloud' to 'nextcloud'. This updated a lot of links to the proper locations, and generally made it clearer that this is Nextcloud notes.

2. This one is more my opinion, but the 'New Note' text should be visible while not hovered over. The pop-in was ugly and jarring and it is much clearer to the user the function of that link.

Any further alterations you would like me to make please just ask.