### PR TITLE
App store: Longer description and small-thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![build state](https://travis-ci.org/nextcloud/notes.png)](https://travis-ci.org/nextcloud/notes) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/notes/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/notes/?branch=master)
 
-The Notes app is a distraction free notes taking app. It offers a [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) for app developers. The source code is [available on GitHub](https://github.com/nextcloud/notes).
+<!-- The following paragraph should be kept synchronized with the description in appinfo/info.xml -->
+The Notes app is a distraction free notes taking app. It supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) allows for an easy integration into third-party apps such as the [Android client](https://github.com/stefan-niedermann/nextcloud-notes). Further features include marking notes as favorites and future versions will provide categories for better organization.
 
 ![Screenshot of Nextcloud Notes](https://cloud.githubusercontent.com/assets/4741199/21027342/b70a6be2-bd90-11e6-9f12-eca46d6c505a.png)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,18 +5,22 @@
     <name>Notes</name>
     <name lang="de">Notizen</name>
     <summary>Distraction-free notes and writing</summary>
-    <description>Distraction-free notes and writing</description>
+    <description><![CDATA[The Notes app is a distraction free notes taking app. It supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) allows for an easy integration into third-party apps such as the [Android client](https://github.com/stefan-niedermann/nextcloud-notes). Further features include marking notes as favorites and future versions will provide categories for better organization.]]></description>
     <version>2.1.1</version>
     <licence>agpl</licence>
     <author>Bernhard Posselt, Jan-Christoph Borchardt, Hendrik Leppelsack</author>
     <namespace>Notes</namespace>
+    <documentation>
+        <user>https://github.com/nextcloud/notes/wiki</user>
+        <developer>https://github.com/nextcloud/notes/wiki</developer>
+    </documentation>
     <category>office</category>
     <category>organization</category>
     <category>tools</category>
     <website>https://github.com/nextcloud/notes</website>
     <bugs>https://github.com/nextcloud/notes/issues</bugs>
     <repository type="git">https://github.com/nextcloud/notes.git</repository>
-    <screenshot>https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
+    <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
     <dependencies>
         <owncloud min-version="8.1" max-version="9.2" />
         <nextcloud min-version="9" max-version="12" />


### PR DESCRIPTION
Currently, there is no meaningful description for the Notes app in the app store. So, here is my suggestion (which should also be in `README.md`):

> The Notes app is a distraction free notes taking app. It supports formatting using [markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) allows for an easy integration into third-party apps such as the [Android client](https://github.com/stefan-niedermann/nextcloud-notes). Further features include marking notes as favorites and future versions will provide categories for better orgnization.

Please spell-check @nextcloud/notes 

I'm also adding a small screenshot, which fixes #40. However, this depends on nextcloud/screenshots#30