### PR TITLE
2.2.0 it is

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
     <name lang="de">Notizen</name>
     <summary>Distraction-free notes and writing</summary>
     <description><![CDATA[The Notes app is a distraction free notes taking app. It supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) allows for an easy integration into third-party apps such as the [Android client](https://github.com/stefan-niedermann/nextcloud-notes). Further features include marking notes as favorites and future versions will provide categories for better organization.]]></description>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <licence>agpl</licence>
     <author>Bernhard Posselt, Jan-Christoph Borchardt, Hendrik Leppelsack</author>
     <namespace>Notes</namespace>


### PR DESCRIPTION
We skip 2.1.1 and directly release the minor update 2.2.0 as we added support for subdirectories in https://github.com/nextcloud/notes/pull/6