### PR TITLE
Convert the file content to UTF-8 if needed

### DIFF
--- a/db/note.php
+++ b/db/note.php
@@ -51,7 +51,7 @@ class Note extends Entity {
     public static function fromFile(File $file, Folder $notesFolder, $tags=[]){
         $note = new static();
         $note->setId($file->getId());
-        $note->setContent($file->getContent());
+        $note->setContent(self::convertEncoding($file->getContent()));
         $note->setModified($file->getMTime());
         $note->setTitle(pathinfo($file->getName(),PATHINFO_FILENAME)); // remove extension
         $subdir = substr(dirname($file->getPath()), strlen($notesFolder->getPath())+1);
@@ -64,4 +64,10 @@ class Note extends Entity {
         return $note;
     }
 
+    private static function convertEncoding($str) {
+        if(!mb_check_encoding($str, 'UTF-8')) {
+            $str = mb_convert_encoding($str, 'UTF-8');
+        }
+        return $str;
+    }
 }


### PR DESCRIPTION
Simple fix for non-UTF-8 files. It's better than showing no notes at all.

Fix #73 and maybe also one part of #77