### PR TITLE
fix #58: allow empty content when create note

### DIFF
--- a/controller/notescontroller.php
+++ b/controller/notescontroller.php
@@ -82,7 +82,7 @@ class NotesController extends Controller {
      *
      * @param string $content
      */
-    public function create($content) {
+    public function create($content="") {
         $note = $this->notesService->create($this->userId);
         $note = $this->notesService->update(
             $note->getId(), $content, $this->userId


### PR DESCRIPTION
This should fix #58 because `content` will not be `null` if it is omitted (which is the case in the JavaScript code).