### PR TITLE
add API to change the category

### DIFF
--- a/controller/notesapicontroller.php
+++ b/controller/notesapicontroller.php
@@ -108,14 +108,15 @@ class NotesApiController extends ApiController {
      * @NoCSRFRequired
      *
      * @param string $content
+     * @param string $category
      * @param int $modified
      * @param boolean $favorite
      * @return DataResponse
      */
-    public function create($content, $modified=0, $favorite=null) {
-        return $this->respond(function () use ($content, $modified, $favorite) {
+    public function create($content, $category=null, $modified=0, $favorite=null) {
+        return $this->respond(function () use ($content, $category, $modified, $favorite) {
             $note = $this->service->create($this->userId);
-            return $this->updateData($note->getId(), $content, $modified, $favorite);
+            return $this->updateData($note->getId(), $content, $category, $modified, $favorite);
         });
     }
 
@@ -127,13 +128,14 @@ class NotesApiController extends ApiController {
      *
      * @param int $id
      * @param string $content
+     * @param string $category
      * @param int $modified
      * @param boolean $favorite
      * @return DataResponse
      */
-    public function update($id, $content=null, $modified=0, $favorite=null) {
-        return $this->respond(function () use ($id, $content, $modified, $favorite) {
-            return $this->updateData($id, $content, $modified, $favorite);
+    public function update($id, $content=null, $category=null, $modified=0, $favorite=null) {
+        return $this->respond(function () use ($id, $content, $category, $modified, $favorite) {
+            return $this->updateData($id, $content, $category, $modified, $favorite);
         });
     }
 
@@ -145,14 +147,14 @@ class NotesApiController extends ApiController {
      * @param boolean $favorite
      * @return Note
      */
-    private function updateData($id, $content, $modified, $favorite) {
+    private function updateData($id, $content, $category, $modified, $favorite) {
         if($favorite!==null) {
             $this->service->favorite($id, $favorite, $this->userId);
         }
         if($content===null) {
             return $this->service->get($id, $this->userId);
         } else {
-            return $this->service->update($id, $content, $this->userId, $modified);
+            return $this->service->update($id, $content, $this->userId, $category, $modified);
         }
     }
 

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -15,6 +15,7 @@ use OCP\Files\FileInfo;
 use OCP\IL10N;
 use OCP\Files\IRootFolder;
 use OCP\Files\Folder;
+use OCP\ILogger;
 
 use OCA\Notes\Db\Note;
 
@@ -27,14 +28,20 @@ class NotesService {
 
     private $l10n;
     private $root;
+    private $logger;
+    private $appName;
 
     /**
      * @param IRootFolder $root
      * @param IL10N $l10n
+     * @param ILogger $logger
+     * @param String $appName
      */
-    public function __construct (IRootFolder $root, IL10N $l10n) {
+    public function __construct (IRootFolder $root, IL10N $l10n, ILogger $logger, $appName) {
         $this->root = $root;
         $this->l10n = $l10n;
+        $this->logger = $logger;
+        $this->appName = $appName;
     }
 
 
@@ -162,7 +169,8 @@ class NotesService {
             if($currentFilePath !== $newFilePath) {
                 $file->move($newFilePath);
             }
-        } catch(\Exception $e) {
+        } catch(\OCP\Files\NotPermittedException $e) {
+            $this->logger->error('Moving this note to the desired target is not allowed. Please check the note\'s target category.', array('app' => $this->appName));
         }
 
         $file->putContent($content);

--- a/tests/integration/controller/NotesApiControllerTest.php
+++ b/tests/integration/controller/NotesApiControllerTest.php
@@ -54,7 +54,7 @@ class NotesApiControllerTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals($note->getId(), $note2->getId());
         $this->assertNotEquals($t, $note2->getModified());
 
-        $note3 = $this->controller->update($note->getId(), 'test3', $t)->getData();
+        $note3 = $this->controller->update($note->getId(), 'test3', null, $t)->getData();
         $this->assertEquals('test3', $note3->getContent());
         $this->assertEquals($note->getId(), $note3->getId());
         $this->assertEquals($t, $note3->getModified());


### PR DESCRIPTION
Since #6 introduced notes from subdirectories and exposes this in the 3rd-party API as `category` (see also #8), we've implemented read-only categories in the Android client (see stefan-niedermann/nextcloud-notes#181). However, there is the demand to change the category from the client.

Therefore, I extended the API to be capable of doing this (fully backward compatible). The implementation on the client-side is already finished (for now in a simple approach, this will be improved later) and the integration can be tested: stefan-niedermann/nextcloud-notes#210

Of course, the web app should be able to display and change categories, too. But my AngularJS skills are limited and there is no agreement on how to layout this new feature. However, this implementation is realized in the `notesservice`, so it can be used by the web app, too.