### PR TITLE
Nextcloud 13 compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ The Notes app is a distraction free notes taking app. It supports formatting usi
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
     <dependencies>
         <owncloud min-version="8.1" max-version="10" />
-        <nextcloud min-version="9" max-version="12" />
+        <nextcloud min-version="9" max-version="13" />
     </dependencies>
     <ocsid>174554</ocsid>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,7 +3,6 @@
       xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
     <id>notes</id>
     <name>Notes</name>
-    <name lang="de">Notizen</name>
     <summary>Distraction-free notes and writing</summary>
     <description><![CDATA[
 The Notes app is a distraction free notes taking app. It supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/stefan-niedermann/nextcloud-notes) and [iOS](https://github.com/owncloud/notes-iOS-App) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites and future versions will provide categories for better organization.


### PR DESCRIPTION
Compatibility with the new Nextcloud development version:

- adjust the max-version

- remove the lang="de" app name. App names are translated in Transifex, no? It also resulted »Array« to be displayed instead of the app name in the upgrade screen:
![screenshot from 2017-06-04 22-48-28](https://cloud.githubusercontent.com/assets/925062/26765249/317dbb4a-4978-11e7-9c33-825b637c18c2.png)


Please review @nextcloud/notes 
