### PR TITLE
Fixed weird fullscreen-button size

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -144,6 +144,9 @@
     transition: none !important;
     -webkit-transition: none !important;
 }
+.btn-fullscreen {
+    padding: 15px;
+}
 
 
 /* markdown styling */

--- a/templates/note.php
+++ b/templates/note.php
@@ -2,6 +2,6 @@
 	<div class="note-meta">
 		{{note.content | wordCount}}
 		<span class="note-meta-right">
-			<button class="icon-fullscreen has-tooltip" notes-tooltip ng-click="toggleDistractionFree()"></button>
+			<button class="icon-fullscreen has-tooltip btn-fullscreen" notes-tooltip ng-click="toggleDistractionFree()"></button>
 		</span>
 	</div>


### PR DESCRIPTION
Added a bit of padding to the button, to make it look better:
<img width="49" alt="capture" src="https://user-images.githubusercontent.com/6009592/27590135-f4c00252-5b4d-11e7-919e-0e56b92deddd.PNG">

