### PR TITLE
Don't show word count on empty note

### DIFF
--- a/templates/note.php
+++ b/templates/note.php
@@ -1,6 +1,6 @@
 	<textarea editor notes-timeout-change="save()" name="editor"></textarea>
 	<div class="note-meta">
-		{{note.content | wordCount}}
+		<span class="note-word-count" ng-if="note.content.length > 0">{{note.content | wordCount}}</span>
 		<span class="note-meta-right">
 			<button class="icon-fullscreen has-tooltip" notes-tooltip ng-click="toggleDistractionFree()"></button>
 		</span>


### PR DESCRIPTION
As proposed here https://github.com/nextcloud/notes/issues/84
Word count in the bottom, is not shown on empty note.