### PR TITLE
fix lost method and version upgrade

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -7,7 +7,7 @@
     <description><![CDATA[
 The Notes app is a distraction free notes taking app. It supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [RESTful API](https://github.com/nextcloud/notes/wiki/API-0.2) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/stefan-niedermann/nextcloud-notes) and [iOS](https://github.com/owncloud/notes-iOS-App) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites and future versions will provide categories for better organization.
 ]]></description>
-    <version>2.2.0</version>
+    <version>2.2.1</version>
     <licence>agpl</licence>
     <author>Bernhard Posselt, Jan-Christoph Borchardt, Hendrik Leppelsack</author>
     <namespace>Notes</namespace>

--- a/service/metaservice.php
+++ b/service/metaservice.php
@@ -59,6 +59,12 @@ class MetaService {
 		return $result;
 	}
 
+	private function create($userId, $note) {
+		$meta = Meta::fromNote($note, $userId);
+		$this->metaMapper->insert($meta);
+		return $meta;
+	}
+
 	private function updateIfNeeded(&$meta, $note) {
 		if($note->getEtag()!==$meta->getEtag()) {
 			$meta->setEtag($note->getEtag());


### PR DESCRIPTION
Sorry, the [job](https://github.com/nextcloud/notes/pull/95#issuecomment-311365201) wasn't that awesome...

I don't know how, but an important PHP method was lost.

And, in order to let the new database table be created, the app's version number has to be increased. This ensures that the API is usable in `master` until the next release.