### PR TITLE
Changed 'new note' to button

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -8,11 +8,6 @@
 	padding-bottom: 0; /* no settings bar, so no padding needed */
 }
 
-#app-navigation #note-add span {
-	font-weight: bold;
-	padding: 10px;
-}
-
 #app-navigation #note-add #new-note-button {
 	margin: 14px auto;
 	width: calc(100% - 20px) !important;

--- a/css/notes.css
+++ b/css/notes.css
@@ -5,16 +5,30 @@
  */
 
 #app-navigation {
-    padding-bottom: 0; /* no settings bar, so no padding needed */
+	padding-bottom: 0; /* no settings bar, so no padding needed */
 }
 
 #app-navigation #note-add span {
-    font-weight: bold;
-    padding-left: 2px;
+	font-weight: bold;
+	padding: 10px;
 }
 
+#app-navigation #note-add #new-note-button {
+	margin: 14px auto;
+	width: calc(100% - 20px) !important;
+	text-align: left;
+	padding-left: 34px;
+	background-position: 10px center;
+}
+  
 #app-navigation .active a {
 	padding-right: 70px;
+}
+
+.app-content-list-button {
+	display: block;
+	margin: 10px auto;
+	padding: 10px;
 }
 
 #app-navigation li .nav-entry {

--- a/css/notes.css
+++ b/css/notes.css
@@ -15,7 +15,7 @@
 	padding-left: 34px;
 	background-position: 10px center;
 }
-  
+
 #app-navigation .active a {
 	padding-right: 70px;
 }

--- a/templates/main.php
+++ b/templates/main.php
@@ -40,10 +40,12 @@ style('notes', [
                 </span>
             </li>
             <!-- new note button -->
-            <li id="note-add" ng-click="create()"
+            <div id="note-add">            
+                <button class="icon-add app-content-list-button ng-binding" id="new-note-button" type="button" name="button" ng-click="create()"
                 oc-click-focus="{ selector: '#app-content textarea' }">
-                <a href='#'>+ <span><?php p($l->t('New note')); ?></span></a>
-            </li>
+                    <?php p($l->t('New note')); ?> 
+                </button>
+            </div>
             <!-- notes list -->
             <li ng-repeat="note in filteredNotes = (notes| and:search | orderBy:['-favorite','-modified'])"
                 ng-class="{ active: note.id == route.noteId }">


### PR DESCRIPTION
As proposed here https://github.com/nextcloud/notes/issues/44, I changed the 'new note' link to a button.

See https://github.com/nextcloud/notes/pull/103 for the previous PR
Had to make a new PR because of a problem with my old fork.

<img width="259" alt="capture" src="https://user-images.githubusercontent.com/6009592/27674621-c20666ee-5ca6-11e7-83c9-1fd816e39465.PNG">
Now the button is similar to the one in Contacts.