### PR TITLE
Sanitise the note's path

### DIFF
--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -142,8 +142,13 @@ class NotesService {
                 $basePath = pathinfo($currentFilePath, PATHINFO_DIRNAME);
             } else {
                 $basePath = $notesFolder->getPath();
-                if(!empty($category))
-                    $basePath .= '/'.$category;
+                if(!empty($category)) {
+                    // sanitise path
+                    $cats = explode('/', $category);
+                    $cats = array_map([$this, 'sanitisePath'], $cats);
+                    $cats = array_filter($cats, function($str) { return !empty($str); });
+                    $basePath .= '/'.implode('/', $cats);
+                }
                 $this->getOrCreateFolder($basePath);
             }
 
@@ -155,7 +160,9 @@ class NotesService {
                 $file->move($newFilePath);
             }
         } catch(\OCP\Files\NotPermittedException $e) {
-            $this->logger->error('Moving this note to the desired target is not allowed. Please check the note\'s target category.', array('app' => $this->appName));
+            $this->logger->error('Moving note '.$id.' ('.$title.') to the desired target is not allowed. Please check the note\'s target category ('.$category.').', ['app' => $this->appName]);
+        } catch(\Exception $e) {
+            $this->logger->error('Moving note '.$id.' ('.$title.') to the desired target has failed with a '.get_class($e).': '.$e->getMessage(), ['app' => $this->appName]);
         }
 
         $file->putContent($content);
@@ -205,15 +212,32 @@ class NotesService {
         $file->delete();
     }
 
+    // removes characters that are illegal in a file or folder name on some operating systems
+    private function sanitisePath($str) {
+        $str = str_replace(['*', '|', '/', '\\', ':', '"', '<', '>', '?'], '', $str); // problematic characters
+        // if mysql doesn't support 4byte UTF-8, then remove those characters
+        if (!\OC::$server->getDatabaseConnection()->supports4ByteText()) {
+            $str = preg_replace('%(?:
+                \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
+              | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
+              | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
+              )%xs', '', $str);
+        }
+        $str = preg_replace("/^[\. ]+/mu", "", $str); // hidden files
+        return trim($str);
+    }
+
     private function getSafeTitleFromContent($content) {
         // prepare content: remove markdown characters and empty spaces
         $content = preg_replace("/^\s*[*+-]\s+/mu", "", $content); // list item
         $content = preg_replace("/^#+\s+(.*?)\s*#*$/mu", "$1", $content); // headline
         $content = preg_replace("/^(=+|-+)$/mu", "", $content); // separate line for headline
         $content = preg_replace("/(\*+|_+)(.*?)\\1/mu", "$2", $content); // emphasis
-        $content = trim($content);
 
-        // generate content from the first line of the title
+        // prevent directory traversal, illegal characters and unintended file names
+        $content = $this->sanitisePath($content);
+
+        // generate title from the first line of the content
         $splitContent = preg_split("/\R/u", $content, 2);
         $title = trim($splitContent[0]);
 
@@ -221,9 +245,6 @@ class NotesService {
         if(empty($title)) {
             $title = $this->l10n->t('New note');
         }
-
-        // prevent directory traversal
-        $title = str_replace(array('/', '\\'), '',  $title);
 
         // using a maximum of 100 chars should be enough
         $title = mb_substr($title, 0, 100, "UTF-8");


### PR DESCRIPTION
I've implemented some enhancements in order to let the notes app to be more fail-safe.

- [x] Remove characters in note's file path (i.e. note's title and category) that are forbidden on other operating systems (i.e. Windows). The problem is, that we can title a note `Math <> Philosophy` on a (linux) server, but when the user wants to synchronize the account with a Windows system, synchronization fails. Therefore, we should remove all characters that lead to failed synchronization (fixes stefan-niedermann/nextcloud-notes#228).
- [x] Renaming a note (e.g. title or category has changed) can lead to an exception. Until now, we only catched the `NotPermittedException` (user has not the right to write to a (shared) folder), but other exceptions can happen, too (e.g. `InvalidPathException` if the filename is invalid due to several reasons). Those are now catched, too. This allows the note content to be saved while although renaming has failed.
- [x] An example for when the `InvalidPathException` is thrown, is when using an emoji in the title and having a MySQL database without 4-byte support. The new function `sanitisePath` removes such illegal characters from the path in such a case (fixes stefan-niedermann/nextcloud-notes#237).