### PR TITLE
Change default file extention

### DIFF
--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -107,7 +107,7 @@ class NotesService {
         // check new note exists already and we need to number it
         // pass -1 because no file has id -1 and that will ensure
         // to only return filenames that dont yet exist
-        $path = $this->generateFileName($folder, $title, "txt", -1);
+        $path = $this->generateFileName($folder, $title, "md", -1);
         $file = $folder->newFile($path);
 
         return Note::fromFile($file, $folder);


### PR DESCRIPTION
Changed txt to md because it's markdown note, it's useful because we can, after download the note, or on windows client or whatever edit the notes with appropriated software

tested on nextcloud 12