### PR TITLE
Moves error messages and word count to top.

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ The Notes app is a distraction free notes taking app. It supports formatting usi
     <screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
     <dependencies>
         <owncloud min-version="8.1" max-version="10" />
-        <nextcloud min-version="9" max-version="13" />
+        <nextcloud min-version="9" max-version="14" />
     </dependencies>
     <ocsid>174554</ocsid>
 </info>

--- a/css/notes.css
+++ b/css/notes.css
@@ -133,9 +133,8 @@
 }
 
 #app-content .note-meta {
-    position: relative;
     padding: 0 45px 30px 45px;
-    margin: -10px 0 0;
+    margin: 10px 0 0;
     -ms-user-select: none;
     -moz-user-select: none;
     -webkit-user-select: none;
@@ -150,10 +149,17 @@
     background-color: #e00;
     color: #fff;
     border-radius: 0.5ex;
-    padding: 0.5ex 1ex;
+    padding: 0.5ex 2ex;
+    margin-right: 10px;
 }
 #app-content .note-meta-right {
     float: right;
+}
+#app-content .note-meta-footer {
+    padding: 0 0 10px 0;
+    z-index: 10;
+    position: fixed;
+    bottom: 10;
 }
 
 #app-content .note-meta > .saving {

--- a/templates/note.php
+++ b/templates/note.php
@@ -1,10 +1,12 @@
-	<textarea editor notes-timeout-change="onEdit()" name="editor"></textarea>
 	<div class="note-meta">
-		<span class="note-word-count" ng-if="note.content.length > 0">{{note.content | wordCount}}</span>
+        <span class="note-error" ng-if="note.error" ng-click="manualSave()" title="<?php p($l->t('Click here to try again')); ?>"><?php p($l->t('Saving failed!')); ?></span>
 		<span class="note-unsaved" ng-if="note.unsaved" title="<?php p($l->t('The note has unsaved changes.')); ?>"><?php p($l->t('*')); ?></span>
-		<span class="note-error" ng-if="note.error" ng-click="manualSave()" title="<?php p($l->t('Click here to try again')); ?>"><?php p($l->t('Saving failed!')); ?></span>
 		<span class="saving" ng-if="isManualSaving()" title="<?php p($l->t('Note saved')); ?>"></span>
 		<span class="note-meta-right">
 			<button class="icon-fullscreen has-tooltip btn-fullscreen" notes-tooltip ng-click="toggleDistractionFree()"></button>
 		</span>
+	</div>
+	<textarea editor notes-timeout-change="onEdit()" name="editor"></textarea>
+	<div class="note-meta note-meta-footer">
+		<span class="note-word-count" ng-if="note.content.length > 0">{{note.content | wordCount}}</span>
 	</div>


### PR DESCRIPTION
Because I have lost notes before because I didn't notice the errors on the bottom of the page.
I also added some extra padding and margin in the error message.

![notes-with-errors](https://user-images.githubusercontent.com/241266/38629975-e716d586-3db5-11e8-8273-a42a6e986eda.png)
![notes-with-no-errors](https://user-images.githubusercontent.com/241266/38629976-e73c9514-3db5-11e8-9a27-4dd8262605cc.png)

cc @jancborchardt @stefan-niedermann 