### PR TITLE
explicit width of editable cell

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -173,6 +173,9 @@
 
 /* markdown styling */
 
+.CodeMirror .CodeMirror-code {
+	width: 100%;
+}
 .CodeMirror .CodeMirror-code .cm-header {
     /* break from core in using semibold, otherwise not emphasized in texts */
 	font-weight: 600;


### PR DESCRIPTION
On mobile, the contenteditable div ends up having a fixed (and small) width [due global CSS](https://github.com/nextcloud/server/blob/123d9f0ce960a3ed0010bc8bcd86273d25ce2d50/core/css/inputs.scss#L30).