### PR TITLE
Remove margin-left offset for any headers after the first in a line

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -239,6 +239,10 @@
     color: rgba(120, 120, 120, 0.5);
 }
 
+.CodeMirror .CodeMirror-code .cm-formatting-header:not(:first-child) {
+    width: auto;
+    margin-left: 0px; 
+}
 
 /* distraction free styles */
 :-webkit-full-screen {


### PR DESCRIPTION
This should address #130, by changing the width and margin-left on any headers after the first in a line.