### PR TITLE
fix: navigation-toggle disappeared in some situations

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -65,12 +65,6 @@
     width: 32px;
 }
 
-/* override snap.js animation causing loading icon to fly into app-content */
-#app-content.loading {
-    transition: none !important;
-    -webkit-transition: none !important;
-}
-
 /* only display the delete button when the feed is active */
 #app-navigation .utils .delete-button {
     display: none;


### PR DESCRIPTION
This applies only, if your browser window's width is less than 786px. Then, the navigation collapses and a hamburger icon is shown. However, this hamburger icon disappeared in some situations.

Steps to reproduce:
- resize your browser window to a width less than 786px
- start notes apps
- the navigation is hidden
- use the hamburger icon to open the navigation
- chose another note from the navigation
- the note is loaded, the navigation is closed again, but the hamburger icon disappeared

This fix removes CSS code, that was introduced with the following comment:
> override snap.js animation causing loading icon to fly into app-content

Hence, now, the loading icon is moved again by snap.js due to closing the navigation. However, this is just a small design problem. The functional bug, that it wasn't possible to use the hamburger icon, is more important, in my view.