### PR TITLE
fix XML validation: remove ocsid

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,5 +26,4 @@ The Notes app is a distraction free notes taking app. It supports formatting usi
         <owncloud min-version="8.1" max-version="10" />
         <nextcloud min-version="9" max-version="14" />
     </dependencies>
-    <ocsid>174554</ocsid>
 </info>


### PR DESCRIPTION
`xmllint` complains about the tag `ocsid` which was used for the Owncloud App-Store. Since that store now has the original owncloud notes-app, we don't need to track this ID anymore. And `xmllint` is happy.