### PR TITLE
fix: database index is too long

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -47,7 +47,7 @@
 				</field>
 			</index>
 			<index>
-				<name>notes_meta_file_id_user_id_index</name>
+				<name>notes_meta_file_user_index</name>
 				<unique>true</unique>
 				<field>
 					<name>file_id</name>


### PR DESCRIPTION
`occ app:check-code notes` complains about an database index' name, which is too long. This fixes this problem.