### PR TITLE
show error message if notes folder has errors

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -61,15 +61,21 @@ class PageController extends Controller {
      * @return TemplateResponse
      */
     public function index() {
+        $errorMessage = null;
         $lastViewedNote = (int) $this->settings->getUserValue($this->userId,
             $this->appName, 'notesLastViewedNote');
-        // check if note exists
+        // check if notes folder is accessible
         try {
-            $this->notesService->get($lastViewedNote, $this->userId);
-            $errorMessage=null;
-        } catch(\Exception $ex) {
-            $lastViewedNote = 0;
-            $errorMessage=$this->l10n->t('The last viewed note cannot be accessed. ').$ex->getMessage();
+            $this->notesService->checkNotesFolder($this->userId);
+            // check if note exists
+            try {
+               $this->notesService->get($lastViewedNote, $this->userId);
+            } catch(\Exception $ex) {
+               $lastViewedNote = 0;
+               $errorMessage = $this->l10n->t('The last viewed note cannot be accessed. ').$ex->getMessage();
+            }
+        } catch(\Exception $e) {
+            $errorMessage = $this->l10n->t('The notes folder is not accessible: %s', $e->getMessage());
         }
 
         $response = new TemplateResponse(

--- a/service/notesfolderexception.php
+++ b/service/notesfolderexception.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Nextcloud - Notes
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ */
+
+namespace OCA\Notes\Service;
+
+use Exception;
+
+/**
+ * Class NotesFolderException
+ *
+ * @package OCA\Notes\Service
+ */
+class NotesFolderException extends Exception {}

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -289,6 +289,14 @@ class NotesService {
         return $file[0];
     }
 
+    /**
+     * @param string $userId the user id
+     * @return boolean true if folder is accessible, or Exception otherwise
+     */
+    public function checkNotesFolder($userId) {
+        $folder = $this->getFolderForUser($userId);
+        return true;
+    }
 
     /**
      * @param string $userId the user id
@@ -296,7 +304,12 @@ class NotesService {
      */
     private function getFolderForUser ($userId) {
         $path = '/' . $userId . '/files/Notes';
-        return $this->getOrCreateFolder($path);
+        try {
+            $folder = $this->getOrCreateFolder($path);
+        } catch(\Exception $e) {
+            throw new NotesFolderException($path);
+        }
+        return $folder;
     }
 
 


### PR DESCRIPTION
Give a more detailed error message when the notes folder is not accessible. This will be especially helpful, when there is a problem with the user-defined notes folder introduced in #207.