### PR TITLE
remove unnecessary confirm button for select

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -100,7 +100,7 @@ style('notes', [
             </div>
             <div class="settings-fileSuffix">
                 <p class="settings-hint"><label for="fileSuffix"><?php p($l->t('File extension for new notes')) ?></label></p>
-                <select id="fileSuffix" ng-model="settings.fileSuffix" ng-options="o as o for o in extensions"></select><input type="submit" class="icon-confirm" value="">
+                <select id="fileSuffix" ng-model="settings.fileSuffix" ng-options="o as o for o in extensions"></select>
             </div>
             </div>
         </div>


### PR DESCRIPTION
References https://github.com/nextcloud/notes/pull/223#issuecomment-411803066 :

> Hehe – ok then I will say it would be great to not have to confirm but simply apply when the select value is changed. :)

@jancborchardt please check, if this is fine, now:

![grafik](https://user-images.githubusercontent.com/6277619/44045811-051f0f28-9f2a-11e8-8fdf-199b052d3a6a.png)
