### PR TITLE
fix: early user detection caused errors

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -13,14 +13,21 @@ use OCA\Notes\Service\SettingsService;
 class SettingsController extends Controller
 {
 	private $service;
+	private $userSession;
 
 	public function __construct(
 		$appName,
 		IRequest $request,
-		SettingsService $service
+		SettingsService $service,
+		IUserSession $userSession
 	) {
 		parent::__construct($appName, $request);
 		$this->service = $service;
+		$this->userSession = $userSession;
+	}
+
+	private function getUID() {
+		return $this->userSession->getUser()->getUID();
 	}
 
 	/**
@@ -28,7 +35,10 @@ class SettingsController extends Controller
 	 * @throws \OCP\PreConditionNotMetException
 	 */
 	public function set() {
-		$this->service->set($this->request->getParams());
+		$this->service->set(
+			$this->getUID(),
+			$this->request->getParams()
+		);
 		return $this->get();
 	}
 
@@ -36,6 +46,6 @@ class SettingsController extends Controller
 	 * @NoAdminRequired
 	 */
 	public function get() {
-		return new JSONResponse($this->service->getAll());
+		return new JSONResponse($this->service->getAll($this->getUID()));
 	}
 }

--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -133,7 +133,7 @@ class NotesService {
         // check new note exists already and we need to number it
         // pass -1 because no file has id -1 and that will ensure
         // to only return filenames that dont yet exist
-        $path = $this->generateFileName($folder, $title, $this->settings->get('fileSuffix'), -1);
+        $path = $this->generateFileName($folder, $title, $this->settings->get($userId, 'fileSuffix'), -1);
         $file = $folder->newFile($path);
 
         // If server-side encryption is activated, the server creates an empty file without signature
@@ -319,7 +319,7 @@ class NotesService {
      * @return Folder
      */
     private function getFolderForUser ($userId) {
-        $path = '/' . $userId . '/files/' . $this->settings->get('notesPath');
+        $path = '/' . $userId . '/files/' . $this->settings->get($userId, 'notesPath');
         try {
             $folder = $this->getOrCreateFolder($path);
         } catch(\Exception $e) {

--- a/service/settingsservice.php
+++ b/service/settingsservice.php
@@ -13,7 +13,6 @@ use OCP\AppFramework\Http\JSONResponse;
 class SettingsService
 {
 	private $config;
-	private $uid;
 	private $root;
 
 	/* Default values */
@@ -23,17 +22,15 @@ class SettingsService
 	];
 
 	public function __construct(
-		IConfig $config,
-		IUserSession $userSession
+		IConfig $config
 	) {
 		$this->config = $config;
-		$this->uid = $userSession->getUser()->getUID();
 	}
 
 	/**
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function set($settings) {
+	public function set($uid, $settings) {
 		// remove illegal, empty and default settings
 		foreach($settings as $name => $value) {
 			if(!array_key_exists($name, $this->defaults)
@@ -43,11 +40,11 @@ class SettingsService
 				unset($settings[$name]);
 			}
 		}
-		$this->config->setUserValue($this->uid, 'notes', 'settings', json_encode($settings));
+		$this->config->setUserValue($uid, 'notes', 'settings', json_encode($settings));
 	}
 
-	public function getAll() {
-		$settings = json_decode($this->config->getUserValue($this->uid, 'notes', 'settings'));
+	public function getAll($uid) {
+		$settings = json_decode($this->config->getUserValue($uid, 'notes', 'settings'));
 		if(is_object($settings)) {
 			// use default for empty settings
 			foreach($this->defaults as $name => $defaultValue) {
@@ -64,12 +61,12 @@ class SettingsService
 	/**
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function get($name) {
-		$settings = $this->getAll();
+	public function get($uid, $name) {
+		$settings = $this->getAll($uid);
 		if(property_exists($settings, $name)) {
 			return $settings->{$name};
 		} else {
-			throw new \OCP\PreConditionNotMetException('Setting '.$name.' not found.');
+			throw new \OCP\PreConditionNotMetException('Setting '.$name.' not found for user '.$uid.'.');
 		}
 	}
 }


### PR DESCRIPTION
When using the 3rd-party API with wrong user credentials (authentification fails), an internal server error (HTTP 500) was returned due to early user detection. With this fix, the correct HTTP response code (40x) is returned.

@stefan-niedermann The Android app now shows "Wrong username or password" again, instead of "URL/Server has errors", when selecting "Connect" in the account settings.

See also owncloud/notes#279