### PR TITLE
Add proper fenced code-block formatting

### DIFF
--- a/css/notes.css
+++ b/css/notes.css
@@ -244,7 +244,11 @@
 
 .CodeMirror .CodeMirror-code .cm-formatting-header:not(:first-child) {
     width: auto;
-    margin-left: 0px; 
+    margin-left: 0px;
+}
+
+.CodeMirror .CodeMirror-code .cm-comment {
+  font-family: MONOSPACE;
 }
 
 /* distraction free styles */

--- a/css/notes.css
+++ b/css/notes.css
@@ -248,7 +248,7 @@
 }
 
 .CodeMirror .CodeMirror-code .cm-comment {
-  font-family: MONOSPACE;
+    font-family: MONOSPACE;
 }
 
 /* distraction free styles */


### PR DESCRIPTION
Markdown defines tripple back-ticks (\`\`\`) as delimiter for code blocks, like
```
this
```
As i use notes extensively to save shell snippets, hack out readme's and the like, them being in a "normal" non monospaced font is extremely inconvenient...

It looks like my proposed change implements this in a quite minimal manner, and as far as my testing goes, doesn't break anything.