### PR TITLE
test if file is a note is now case insensitive

### DIFF
--- a/service/notesservice.php
+++ b/service/notesservice.php
@@ -409,11 +409,12 @@ class NotesService {
         $allowedExtensions = ['txt', 'org', 'markdown', 'md', 'note'];
 
         if($file->getType() !== 'file') return false;
-        if(!in_array(
-            pathinfo($file->getName(), PATHINFO_EXTENSION),
-            $allowedExtensions
-        )) return false;
 
+        $ext = pathinfo($file->getName(), PATHINFO_EXTENSION);
+        $iext = strtolower($ext);
+        if(!in_array($iext, $allowedExtensions)) {
+            return false;
+        }
         return true;
     }
 


### PR DESCRIPTION
This detects also `TEST.TXT` and not only `test.txt` as valid note.