### PR TITLE
group list of notes by timeslots

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -2,7 +2,7 @@
 	font-weight: bold;
 }
 
-#app-navigation > ul > li.app-navigation-caption {
+#app-navigation > ul > li.app-navigation-caption.caption-item {
 	padding: 0;
 	pointer-events: inherit;
 }

--- a/src/components/NavigationList.vue
+++ b/src/components/NavigationList.vue
@@ -97,6 +97,7 @@ export default {
 			return store.getters.numNotes()
 		},
 
+		// group notes by time ("All notes") or by category (if category chosen)
 		groupedNotes() {
 			if (this.category === null) {
 				return this.filteredNotes.reduce((g, note) => {
@@ -131,6 +132,7 @@ export default {
 	methods: {
 		updateTimeslots() {
 			const now = new Date()
+			// define the time groups we want to allow
 			this.timeslots = [
 				{ t: new Date(now.getFullYear(), now.getMonth(), now.getDate()), l: t('notes', 'Today') },
 				{ t: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1), l: t('notes', 'Yesterday') },
@@ -164,12 +166,10 @@ export default {
 				return ''
 			}
 			const t = note.modified * 1000
-			for (const timeslot of this.timeslots) {
-				if (t >= timeslot.t.getTime()) {
-					return timeslot.l
-				}
-			}
-			if (t >= this.lastYear) {
+			const timeslot = this.timeslots.find(timeslot => t >= timeslot.t.getTime())
+			if (timeslot !== undefined) {
+				return timeslot.l
+			} else if (t >= this.lastYear) {
 				return this.monthFormat.format(new Date(t))
 			} else {
 				return new Date(t).getFullYear()


### PR DESCRIPTION
Introduces labels for timeslots based on the last modified date, like we already have in the Android app and as discussed in https://github.com/stefan-niedermann/nextcloud-notes/issues/539

We have the following timeslots:
- Today
- Yesterday
- This week
- Last week
- This month
- Last month
- *[Month] [Year]*, e.g. *April 2019*
- *[Year]*, e.g. *2016*

*Month Year* is used for all dates which are before the last month but only in this year and last year. Older notes are grouped in *Year*.

![Screenshot 1](https://user-images.githubusercontent.com/6277619/58281213-e1eb9f00-7da2-11e9-8afb-e7742841437f.png)

![Screenshot 2](https://user-images.githubusercontent.com/6277619/58281538-aa312700-7da3-11e9-8cb2-b285a520aaec.png)

Please review @nextcloud/notes @nextcloud/designers 