### PR TITLE
preview mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1623,7 +1623,6 @@
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
 			}
@@ -3181,8 +3180,7 @@
 		"entities": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-			"dev": true
+			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
 		},
 		"errno": {
 			"version": "0.1.7",
@@ -5732,6 +5730,14 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"linkify-it": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.1.0.tgz",
+			"integrity": "sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==",
+			"requires": {
+				"uc.micro": "^1.0.1"
+			}
+		},
 		"load-json-file": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -5956,6 +5962,18 @@
 			"integrity": "sha512-lbRZ2mE3Q9RtLjxZBZ9+IMl68DKIXaVAhwvwn9pmjnPLS0h/6kyBMgNhqi1xFJ/2yv6cSyv0jbiZavZv93JkkA==",
 			"dev": true
 		},
+		"markdown-it": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+			"integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+			"requires": {
+				"argparse": "^1.0.7",
+				"entities": "~1.1.1",
+				"linkify-it": "^2.0.0",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			}
+		},
 		"markdown-table": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.2.tgz",
@@ -6002,6 +6020,11 @@
 			"requires": {
 				"unist-util-visit": "^1.1.0"
 			}
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
 		},
 		"mem": {
 			"version": "4.3.0",
@@ -8264,8 +8287,7 @@
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-			"dev": true
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -9163,6 +9185,11 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/typo-js/-/typo-js-1.0.3.tgz",
 			"integrity": "sha1-VNjrx5SfGngQkItgAsaEFSbJnVo="
+		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
 		},
 		"unherit": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"@babel/polyfill": "^7.4.4",
 		"easymde": "^2.6.0",
+		"markdown-it": "^8.4.2",
 		"nextcloud-axios": "^0.2.0",
 		"nextcloud-vue": "^0.11.4",
 		"vue": "^2.6.10",

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -96,7 +96,6 @@ export default {
 
 .markdown-editor {
 	min-height: 100%;
-	padding: 1em;
 }
 
 .CodeMirror {

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -42,7 +42,7 @@ export default {
 </script>
 <style lang="scss">
 .note-preview {
-	padding: 1em;
+	padding: 0 1em;
 	line-height: 1.5em;
 
 	& h1, & h2, & h3, & h4, & h5, & h6 {

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -1,0 +1,116 @@
+<template>
+	<div class="note-preview" v-html="html" />
+</template>
+<script>
+
+import MarkdownIt from 'markdown-it'
+
+export default {
+	name: 'ThePreview',
+
+	props: {
+		value: {
+			type: String,
+			required: true,
+		},
+	},
+
+	data: function() {
+		return {
+			html: '',
+			md: new MarkdownIt({
+				linkify: true,
+			}),
+		}
+	},
+
+	watch: {
+		value: 'onUpdate',
+	},
+
+	created() {
+		this.onUpdate()
+	},
+
+	methods: {
+		onUpdate() {
+			this.html = this.md.render(this.value)
+		},
+	},
+
+}
+</script>
+<style lang="scss">
+.note-preview {
+	padding: 1em;
+	line-height: 1.5em;
+
+	& h1, & h2, & h3, & h4, & h5, & h6 {
+		padding: 0;
+		margin-top: 2ex;
+		margin-bottom: 1ex;
+		font-weight: bold;
+		color: inherit;
+	}
+
+	& h1 {
+		font-size: 165%;
+	}
+
+	& h2 {
+		font-size: 140%;
+	}
+
+	& h3 {
+		font-size: 120%;
+	}
+
+	& h4 {
+		font-size: 110%;
+	}
+
+	& p, & pre, & ul, & ol {
+		margin: 2ex 0;
+	}
+
+	& ul {
+		list-style: initial;
+	}
+
+	& ul, & ol {
+		margin-left: 3ex;
+	}
+
+	& li > p, & li > ul, & li > ol {
+		margin-top: 0.5ex;
+		margin-bottom: 0.5ex;
+	}
+
+	& em {
+		font-style: italic;
+		color: inherit;
+	}
+
+	& a {
+		color: var(--color-primary);
+	}
+
+	& pre, & code {
+		background: var(--color-background-dark);
+		font-size: 90%;
+		padding: 0.2ex 0.5ex;
+	}
+
+	& pre code {
+		font-size: inherit;
+		padding: 0;
+	}
+
+	& blockquote {
+		font-style: italic;
+		border-left: 4px solid var(--color-border);
+		padding-left: 2ex;
+		color: var(--color-text-light)
+	}
+}
+</style>

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -21,26 +21,26 @@
 						icon="icon-details"
 						@click="onToggleSidebar"
 					>
-						{{ t('notes', 'Show sidebar') }}
+						{{ t('notes', 'Details') }}
 					</ActionButton>
 					<ActionButton v-show="!preview"
 						icon="icon-toggle"
 						@click="onTogglePreview"
 					>
-						{{ t('notes', 'Show preview') }}
+						{{ t('notes', 'Preview') }}
 					</ActionButton>
 					<ActionButton v-show="preview"
 						icon="icon-rename"
 						@click="onTogglePreview"
 					>
-						{{ t('notes', 'Edit note') }}
+						{{ t('notes', 'Edit') }}
 					</ActionButton>
 					<ActionButton
 						icon="icon-fullscreen"
 						:class="{ active: fullscreen }"
 						@click="onToggleDistractionFree"
 					>
-						{{ t('notes', 'Fullscreen mode') }}
+						{{ t('notes', 'Fullscreen') }}
 					</ActionButton>
 				</Actions>
 			</span>

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -16,7 +16,7 @@
 					class="icon-error-color"
 					@click="onManualSave"
 				/>
-				<Actions :open.sync="actionsOpen" menuAlign="right">
+				<Actions :open.sync="actionsOpen" menu-align="right">
 					<ActionButton v-show="!sidebarOpen && !fullscreen"
 						icon="icon-details"
 						@click="onToggleSidebar"

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -16,29 +16,33 @@
 					class="icon-error-color"
 					@click="onManualSave"
 				/>
-				<button v-show="actionsOpen && !fullscreen"
-					v-tooltip="t('notes', 'Toggle sidebar')"
-					class="icon-details"
-					@click="onToggleSidebar"
-				/>
-				<button v-show="actionsOpen"
-					v-tooltip="t('notes', 'Toggle preview')"
-					class="icon-toggle"
-					:class="{ active: preview }"
-					@click="onTogglePreview"
-				/>
-				<button v-show="actionsOpen"
-					v-tooltip="t('notes', 'Toggle fullscreen mode')"
-					class="icon-fullscreen"
-					:class="{ active: fullscreen }"
-					@click="onToggleDistractionFree"
-				/>
-				<button
-					v-tooltip="t('notes', 'Toggle action menu')"
-					class="icon-more"
-					:class="{ active: actionsOpen }"
-					@click="onToggleActions"
-				/>
+				<Actions :open.sync="actionsOpen" menuAlign="right">
+					<ActionButton v-show="!sidebarOpen && !fullscreen"
+						icon="icon-details"
+						@click="onToggleSidebar"
+					>
+						{{ t('notes', 'Show sidebar') }}
+					</ActionButton>
+					<ActionButton v-show="!preview"
+						icon="icon-toggle"
+						@click="onTogglePreview"
+					>
+						{{ t('notes', 'Show preview') }}
+					</ActionButton>
+					<ActionButton v-show="preview"
+						icon="icon-rename"
+						@click="onTogglePreview"
+					>
+						{{ t('notes', 'Edit note') }}
+					</ActionButton>
+					<ActionButton
+						icon="icon-fullscreen"
+						:class="{ active: fullscreen }"
+						@click="onToggleDistractionFree"
+					>
+						{{ t('notes', 'Fullscreen mode') }}
+					</ActionButton>
+				</Actions>
 			</span>
 		</div>
 	</AppContent>
@@ -46,6 +50,8 @@
 <script>
 
 import {
+	Actions,
+	ActionButton,
 	AppContent,
 	Tooltip,
 } from 'nextcloud-vue'
@@ -58,6 +64,8 @@ export default {
 	name: 'Note',
 
 	components: {
+		Actions,
+		ActionButton,
 		AppContent,
 		TheEditor,
 		ThePreview,
@@ -191,10 +199,6 @@ export default {
 			this.actionsOpen = false
 		},
 
-		onToggleActions() {
-			this.actionsOpen = !this.actionsOpen
-		},
-
 		onEdit(newContent) {
 			if (this.note.content !== newContent) {
 				const note = {
@@ -274,9 +278,14 @@ export default {
 /* main editor button */
 .action-buttons {
 	position: fixed;
-	bottom: 4px;
+	top: 50px;
 	right: 20px;
+	margin-top: 1em;
 	z-index: 2000;
+}
+
+.note-container.fullscreen .action-buttons {
+	top: 0px;
 }
 
 .action-buttons button {

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -5,7 +5,7 @@
 		>
 			<div class="note-editor">
 				<div v-show="!note.content" class="placeholder">
-					{{ t('notes', 'Write …') }}
+					{{ preview ? t('notes', 'Empty note') : t('notes', 'Write …') }}
 				</div>
 				<ThePreview v-if="preview" :value="note.content" />
 				<TheEditor v-else :value="note.content" @input="onEdit" />
@@ -234,7 +234,7 @@ export default {
 .note-editor {
 	max-width: 47em;
 	font-size: 16px;
-	padding: 0 1em;
+	padding: 1em;
 }
 
 /* center editor on large screens */
@@ -267,7 +267,7 @@ export default {
 /* placeholder */
 .placeholder {
 	position: absolute;
-	padding: 2em;
+	padding: 1em;
 	opacity: 0.5;
 }
 


### PR DESCRIPTION
This adds a preview mode, in which the formatted text is shown without any possibility to edit. Implementation uses `MarkdownIt`. Fixes #23.

- [x] new component `EditorMarkdownIt` for preview mode
- [x] toggle preview mode with action button (bottom right)
- [x] introduce three-dot-menu for action buttons (bottom right)

### Screenshots

#### Normal editor (like before)
![editor](https://user-images.githubusercontent.com/6277619/58377994-8e887500-7f8b-11e9-9c4c-4c95c71158ec.png)

### Action menu closed (bottom right)
![action menu closed](https://user-images.githubusercontent.com/6277619/58378000-a9f38000-7f8b-11e9-86b0-13f9b95c825c.png)

### Action menu opened (bottom right)
![action menu opened](https://user-images.githubusercontent.com/6277619/58378003-b2e45180-7f8b-11e9-89ea-0669335d2942.png)

### Action menu: Preview active (bottom right)
![action menu preview active](https://user-images.githubusercontent.com/6277619/58378008-c0014080-7f8b-11e9-94b4-cb4b0b5d76e9.png)

### New Preview
![preview](https://user-images.githubusercontent.com/6277619/58378013-c8597b80-7f8b-11e9-8077-692cdc72436f.png)
