### PR TITLE
Potential fix for #326

### DIFF
--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -190,7 +190,10 @@ class NotesService {
 		}
 
 		if ($content !== null) {
-			$file->putContent($content);
+			$stream = fopen('php://temp', 'r+');
+			fwrite($stream, $content);
+			rewind($stream);
+			$file->putContent($stream);
 		}
 
 		if ($mtime) {


### PR DESCRIPTION
It appears that the ObjectStore Storage implementation [puts the file contents into the php temp stream](https://github.com/nextcloud/server/blob/master/lib/private/Files/ObjectStore/ObjectStoreStorage.php#L412), which is [passed](https://github.com/nextcloud/server/blob/master/lib/private/Files/ObjectStore/S3ObjectTrait.php#L85) to the S3 uploader, which for whatever reason [tries to reopen the underlying file of the stream](https://github.com/nextcloud/3rdparty/blob/ef289bc27eae0cdfc3f74f419ace8dda8dd84ef0/aws/aws-sdk-php/src/S3/MultipartUploader.php#L110), which happens to be the php temp stream, which is *not reusable by passing its uri* and is thus empty.

A quick fix, if the above theory is correct, would be to pass the contents as a stream to putContents(), which forces nextcloud to write the stream to disk in a temp file and thus avoids the failing S3 upload, as the aws uploader now has an actual file to work with instead of the temp stream.

I cannot test this myself, as I lack access to an S3 instance.
If this fix works, an upstream fix in nextcloud would be in order as well.

Fixes #326