### PR TITLE
fix null error in Sidebar subtitle

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -113,7 +113,7 @@ export default {
 				).length
 				return n('notes', '%n word', '%n words', wordCount)
 			} else {
-				return null
+				return ''
 			}
 		},
 		subtitle() {


### PR DESCRIPTION
When opening the sidebar for an empty note, the following error occurred: 
> t.subtitle is null