### PR TITLE
Set font color to black for printing.

### DIFF
--- a/css/print.scss
+++ b/css/print.scss
@@ -8,6 +8,7 @@
 	#content {
 		display: block;
 		padding: 0;
+		color: #000;
 	}
 
 	#note-container .note-editor,


### PR DESCRIPTION
When printing a note with the dark style, the font color is a rather light gray. This patch sets the font color to black during printing.
