### PR TITLE
add manifest.json

### DIFF
--- a/img/manifest.json
+++ b/img/manifest.json
@@ -1,14 +1,14 @@
 {
 	"name": "Notes",
-	"start_url": "/apps/notes/",
+	"start_url": "../../../apps/notes",
 	"icons": [
 		{
-			"src": "/apps/notes/img/favicon-touch.png",
+			"src": "./favicon-touch.png",
 			"type": "image/png",
 			"sizes": "128x128"
 		},
 		{
-			"src": "/apps/notes/img/favicon-touch.svg",
+			"src": "./favicon-touch.svg",
 			"type": "image/svg+xml",
 			"sizes": "16x16"
 		}

--- a/img/manifest.json
+++ b/img/manifest.json
@@ -1,0 +1,17 @@
+{
+	"name": "Notes",
+	"start_url": "/apps/notes/",
+	"icons": [
+		{
+			"src": "/apps/notes/img/favicon-touch.png",
+			"type": "image/png",
+			"sizes": "128x128"
+		},
+		{
+			"src": "/apps/notes/img/favicon-touch.svg",
+			"type": "image/svg+xml",
+			"sizes": "16x16"
+		}
+	],
+	"display": "standalone"
+}


### PR DESCRIPTION
I use notes daily and love it. ❤️

I tried many options for a front end on mobile phone, but I find that the web version is just right (a part of some small things, that I will try to fix later).

## Motivation

The thing is that when you tap «Add to Home screen» in `chrome` it always saves the `Nextcloud` default app (i.e. `files`) which is in the way when you're trying to quickly add some note.

## Solution

I've looked through the code that is responsible of adding the manifest file and found that there is a default app -- `theming` that looks if the `apps/<app>/img/manifest.json` file is available and adds it otherwise it generates its own `manifest` in the [ThemingDefaults.php](https://github.com/nextcloud/server/blob/2442d78696313744bae8170c1b547f3b50ca8fcd/apps/theming/lib/ThemingDefaults.php#L347-L355) file:
```php
if ($image === 'manifest.json') {
	try {
		$appPath = $this->appManager->getAppPath($app);
		if (file_exists($appPath . '/img/manifest.json')) {
			return false;
		}
	} catch (AppPathNotFoundException $e) {}
	$route = $this->urlGenerator->linkToRoute('theming.Theming.getManifest');
}
```

but then the main [`.htaccess`](https://github.com/nextcloud/server/blob/2442d78696313744bae8170c1b547f3b50ca8fcd/lib/private/Setup.php#L525) file is redirecting all the files to `/`.

So I decided to make a [pull request](https://github.com/nextcloud/server/pull/18584) there where I would allow apps to have their proper `manifest` files.

## Result

With changes to server and the `manifest.json` within this PR I get:
![image](https://user-images.githubusercontent.com/1726487/71543673-dafabf80-2975-11ea-8bce-7fb2880c376e.png)

And I'm able to save `Notes` app to desktop and access it quickly.

P.S. I also created a [`sandbox`](https://github.com/gko/nextcloud-sandbox) to be able to quickly debug apps.