### PR TITLE
initially show first notes only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9567,6 +9567,11 @@
 			"resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
 			"integrity": "sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w=="
 		},
+		"vue-observe-visibility": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/vue-observe-visibility/-/vue-observe-visibility-0.4.6.tgz",
+			"integrity": "sha512-xo0CEVdkjSjhJoDdLSvoZoQrw/H2BlzB5jrCBKGZNXN2zdZgMuZ9BKrxXDjNP2AxlcCoKc8OahI3F3r3JGLv2Q=="
+		},
 		"vue-resize": {
 			"version": "0.4.5",
 			"resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-0.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"easymde": "^2.8.0",
 		"markdown-it": "^10.0.0",
 		"vue": "^2.6.11",
+		"vue-observe-visibility": "^0.4.6",
 		"vue-router": "^3.1.3",
 		"vuex": "^3.1.2"
 	},


### PR DESCRIPTION
Improves speed when switching between categories if there are many notes.

Background: there are many DOM operations done by VueJS in order to show the list of notes in the app navigation. This can be reduced (moved to later) with these changes.

Solution: Initially shows max. 30 notes in app navigation and the entry "Loading ..." at the bottom. If that entry becomes visible (because the user scrolls down), all further notes are shown. With this approach, the initial rendering time is reduced and moved to the point of time when the user wants to see the whole list of notes (which is likely to be seldom the case).