### PR TITLE
new undo design using notifications

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Setup xmllint
-      run: sudo apt-get install --no-install-recommends -y libxml2-utils
+      run: |
+        sudo apt update
+        sudo apt install --no-install-recommends -y libxml2-utils
     - name: Setup xmllint problem matcher
       uses: korelstar/xmllint-problem-matcher@master
     - name: lint XML

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -48,6 +48,11 @@ return ['routes' => [
 		'verb' => 'POST',
 	],
 	[
+		'name' => 'notes#undo',
+		'url' => '/notes/undo',
+		'verb' => 'POST',
+	],
+	[
 		'name' => 'notes#update',
 		'url' => '/notes/{id}',
 		'verb' => 'PUT',

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -143,6 +143,34 @@ class NotesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * @param string $content
+	 */
+	public function undo($id, $content, $category, $modified, $favorite) {
+		try {
+			// check if note still exists
+			$note = $this->notesService->get($id, $this->userId);
+			if ($note->getError()) {
+				throw new \Exception();
+			}
+		} catch (\Throwable $e) {
+			// re-create if note doesn't exit anymore
+			$note = $this->notesService->create($this->userId);
+			$note = $this->notesService->update(
+				$note->getId(),
+				$content,
+				$this->userId,
+				$category,
+				$modified
+			);
+			$note->favorite = $this->notesService->favorite($note->getId(), $favorite, $this->userId);
+		}
+		return new DataResponse($note);
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 *
 	 * @param int $id
 	 * @param string $content
 	 * @return DataResponse

--- a/src/components/NavigationCategoriesItem.vue
+++ b/src/components/NavigationCategoriesItem.vue
@@ -14,7 +14,7 @@
 				icon="icon-recent"
 				@click.prevent.stop="onSelectCategory(null)"
 			>
-				<AppNavigationCounter slot="counter">
+				<AppNavigationCounter #counter>
 					{{ numNotes }}
 				</AppNavigationCounter>
 			</AppNavigationItem>
@@ -25,7 +25,7 @@
 				:icon="category.name === '' ? 'icon-emptyfolder' : 'icon-files'"
 				@click.prevent.stop="onSelectCategory(category.name)"
 			>
-				<AppNavigationCounter slot="counter">
+				<AppNavigationCounter #counter>
 					{{ category.count }}
 				</AppNavigationCounter>
 			</AppNavigationItem>

--- a/src/components/NavigationList.vue
+++ b/src/components/NavigationList.vue
@@ -42,7 +42,7 @@
 				:key="note.id"
 				:note="note"
 				@category-selected="$emit('category-selected', $event)"
-				@note-deleted="$emit('note-deleted')"
+				@note-deleted="$emit('note-deleted', $event)"
 			/>
 		</template>
 		<AppNavigationItem

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -57,6 +57,7 @@ import {
 	AppContent,
 	Tooltip,
 } from '@nextcloud/vue'
+import { showError } from '@nextcloud/dialogs'
 
 import { fetchNote, saveNote, saveNoteManually } from '../NotesService'
 import { closeNavbar } from '../nextcloud'
@@ -141,7 +142,7 @@ export default {
 			fetchNote(this.noteId)
 				.then((note) => {
 					if (note.errorMessage) {
-						OC.Notification.showTemporary(note.errorMessage)
+						showError(note.errorMessage)
 					}
 				})
 				.catch(() => {


### PR DESCRIPTION
Fixes  #417, see discussion under https://github.com/nextcloud/nextcloud-vue/issues/705, especially https://github.com/nextcloud/nextcloud-vue/issues/705#issuecomment-549194181. Thanks to @paulschwoerer for help on implementing this. For now, I'm using the (old) `OC.Notification` API, since I want to be compatible to Nextcloud 15/16. We will switch to the new `OCP.Toast` API later.

![grafik](https://user-images.githubusercontent.com/6277619/71772096-90fd7500-2f45-11ea-93be-960147d06efd.png)

@jancborchardt Is this how you imagined?