### PR TITLE
improved error handling

### DIFF
--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -10,6 +10,7 @@ use OCP\IUserSession;
 
 use OCA\Notes\Service\NotesService;
 use OCA\Notes\Service\MetaService;
+use OCA\Notes\Service\InsufficientStorageException;
 use OCA\Notes\Db\Note;
 
 /**
@@ -131,15 +132,19 @@ class NotesApiController extends ApiController {
 	 * @return DataResponse
 	 */
 	public function create($content, $category = null, $modified = 0, $favorite = null) {
-		$note = $this->service->create($this->getUID());
 		try {
-			$note = $this->updateData($note->getId(), $content, $category, $modified, $favorite);
-		} catch (\Throwable $e) {
-			// roll-back note creation
-			$this->service->delete($note->getId(), $this->getUID());
-			throw $e;
+			$note = $this->service->create($this->getUID());
+			try {
+				$note = $this->updateData($note->getId(), $content, $category, $modified, $favorite);
+			} catch (\Throwable $e) {
+				// roll-back note creation
+				$this->service->delete($note->getId(), $this->getUID());
+				throw $e;
+			}
+			return new DataResponse($note);
+		} catch (InsufficientStorageException $e) {
+			return new DataResponse([], Http::STATUS_INSUFFICIENT_STORAGE);
 		}
-		return new DataResponse($note);
 	}
 
 
@@ -156,8 +161,12 @@ class NotesApiController extends ApiController {
 	 * @return DataResponse
 	 */
 	public function update($id, $content = null, $category = null, $modified = 0, $favorite = null) {
-		$note = $this->updateData($id, $content, $category, $modified, $favorite);
-		return new DataResponse($note);
+		try {
+			$note = $this->updateData($id, $content, $category, $modified, $favorite);
+			return new DataResponse($note);
+		} catch (InsufficientStorageException $e) {
+			return new DataResponse([], Http::STATUS_INSUFFICIENT_STORAGE);
+		}
 	}
 
 	/**

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -113,12 +113,9 @@ class NotesApiController extends ApiController {
 	 */
 	public function get($id, $exclude = '') {
 		$exclude = explode(',', $exclude);
-
-		return $this->respond(function () use ($id, $exclude) {
-			$note = $this->service->get($id, $this->getUID());
-			$note = $this->excludeFields($note, $exclude);
-			return $note;
-		});
+		$note = $this->service->get($id, $this->getUID());
+		$note = $this->excludeFields($note, $exclude);
+		return new DataResponse($note);
 	}
 
 
@@ -134,16 +131,15 @@ class NotesApiController extends ApiController {
 	 * @return DataResponse
 	 */
 	public function create($content, $category = null, $modified = 0, $favorite = null) {
-		return $this->respond(function () use ($content, $category, $modified, $favorite) {
-			$note = $this->service->create($this->getUID());
-			try {
-				$note = $this->updateData($note->getId(), $content, $category, $modified, $favorite);
-			} catch(\Throwable $e) {
-				// roll-back note creation
-				$this->service->delete($note->getId(), $this->getUID());
-				throw $e;
-			}
-		});
+		$note = $this->service->create($this->getUID());
+		try {
+			$note = $this->updateData($note->getId(), $content, $category, $modified, $favorite);
+		} catch (\Throwable $e) {
+			// roll-back note creation
+			$this->service->delete($note->getId(), $this->getUID());
+			throw $e;
+		}
+		return new DataResponse($note);
 	}
 
 
@@ -160,9 +156,8 @@ class NotesApiController extends ApiController {
 	 * @return DataResponse
 	 */
 	public function update($id, $content = null, $category = null, $modified = 0, $favorite = null) {
-		return $this->respond(function () use ($id, $content, $category, $modified, $favorite) {
-			return $this->updateData($id, $content, $category, $modified, $favorite);
-		});
+		$note = $this->updateData($id, $content, $category, $modified, $favorite);
+		return new DataResponse($note);
 	}
 
 	/**
@@ -193,9 +188,7 @@ class NotesApiController extends ApiController {
 	 * @return DataResponse
 	 */
 	public function destroy($id) {
-		return $this->respond(function () use ($id) {
-			$this->service->delete($id, $this->getUID());
-			return [];
-		});
+		$this->service->delete($id, $this->getUID());
+		return new DataResponse([]);
 	}
 }

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -136,7 +136,13 @@ class NotesApiController extends ApiController {
 	public function create($content, $category = null, $modified = 0, $favorite = null) {
 		return $this->respond(function () use ($content, $category, $modified, $favorite) {
 			$note = $this->service->create($this->getUID());
-			return $this->updateData($note->getId(), $content, $category, $modified, $favorite);
+			try {
+				$note = $this->updateData($note->getId(), $content, $category, $modified, $favorite);
+			} catch(\Throwable $e) {
+				// roll-back note creation
+				$this->service->delete($note->getId(), $this->getUID());
+				throw $e;
+			}
 		});
 	}
 

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -6,10 +6,12 @@ use OCP\AppFramework\Controller;
 use OCP\IRequest;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 
 use OCA\Notes\Service\NotesService;
 use OCA\Notes\Service\SettingsService;
+use OCA\Notes\Service\InsufficientStorageException;
 
 /**
  * Class NotesController
@@ -123,14 +125,18 @@ class NotesController extends Controller {
 	 * @param string $content
 	 */
 	public function create($content = '', $category = null) {
-		$note = $this->notesService->create($this->userId);
-		$note = $this->notesService->update(
-			$note->getId(),
-			$content,
-			$this->userId,
-			$category
-		);
-		return new DataResponse($note);
+		try {
+			$note = $this->notesService->create($this->userId);
+			$note = $this->notesService->update(
+				$note->getId(),
+				$content,
+				$this->userId,
+				$category
+			);
+			return new DataResponse($note);
+		} catch (InsufficientStorageException $e) {
+			return new DataResponse([], Http::STATUS_INSUFFICIENT_STORAGE);
+		}
 	}
 
 
@@ -142,8 +148,12 @@ class NotesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function update($id, $content) {
-		$note = $this->notesService->update($id, $content, $this->userId);
-		return new DataResponse($note);
+		try {
+			$note = $this->notesService->update($id, $content, $this->userId);
+			return new DataResponse($note);
+		} catch (InsufficientStorageException $e) {
+			return new DataResponse([], Http::STATUS_INSUFFICIENT_STORAGE);
+		}
 	}
 
 

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -112,9 +112,8 @@ class NotesController extends Controller {
 			$id
 		);
 
-		return $this->respond(function () use ($id) {
-			return $this->notesService->get($id, $this->userId);
-		});
+		$note = $this->notesService->get($id, $this->userId);
+		return new DataResponse($note);
 	}
 
 
@@ -143,9 +142,8 @@ class NotesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function update($id, $content) {
-		return $this->respond(function () use ($id, $content) {
-			return $this->notesService->update($id, $content, $this->userId);
-		});
+		$note = $this->notesService->update($id, $content, $this->userId);
+		return new DataResponse($note);
 	}
 
 
@@ -158,10 +156,8 @@ class NotesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function category($id, $category) {
-		return $this->respond(function () use ($id, $category) {
-			$note = $this->notesService->update($id, null, $this->userId, $category);
-			return $note->category;
-		});
+		$note = $this->notesService->update($id, null, $this->userId, $category);
+		return new DataResponse($note->category);
 	}
 
 
@@ -173,9 +169,8 @@ class NotesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function favorite($id, $favorite) {
-		return $this->respond(function () use ($id, $favorite) {
-			return $this->notesService->favorite($id, $favorite, $this->userId);
-		});
+		$result = $this->notesService->favorite($id, $favorite, $this->userId);
+		return new DataResponse($result);
 	}
 
 
@@ -186,9 +181,7 @@ class NotesController extends Controller {
 	 * @return DataResponse
 	 */
 	public function destroy($id) {
-		return $this->respond(function () use ($id) {
-			$this->notesService->delete($id, $this->userId);
-			return [];
-		});
+		$this->notesService->delete($id, $this->userId);
+		return new DataResponse([]);
 	}
 }

--- a/lib/Service/InsufficientStorageException.php
+++ b/lib/Service/InsufficientStorageException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Notes\Service;
+
+use Exception;
+
+class InsufficientStorageException extends Exception {
+}

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -126,6 +126,9 @@ class NotesService {
 	public function create($userId) : Note {
 		$title = $this->l10n->t('New note');
 		$folder = $this->getFolderForUser($userId);
+		if ($folder->getFreeSpace() <= 1) {
+			throw new InsufficientStorageException();
+		}
 
 		// check new note exists already and we need to number it
 		// pass -1 because no file has id -1 and that will ensure
@@ -180,6 +183,9 @@ class NotesService {
 		}
 
 		if ($content !== null) {
+			if ($file->getParent()->getFreeSpace() < strlen($content)) {
+				throw new InsufficientStorageException();
+			}
 			$file->putContent($content);
 		}
 

--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -15,6 +15,10 @@ export default {
 		OC.Notification.showTemporary(message + ' ' + this.t('notes', 'See JavaScript console for details.'))
 	},
 
+	handleInsufficientStorage() {
+		OC.Notification.showTemporary(this.t('notes', 'Saving the note has failed due to insufficient storage.'))
+	},
+
 	setSettings(settings) {
 		return axios
 			.put(this.url('/settings'), settings)
@@ -81,7 +85,11 @@ export default {
 			})
 			.catch(err => {
 				console.error(err)
-				this.handleSyncError(this.t('notes', 'Creating new note has failed.'))
+				if (err.response.status === 507) {
+					this.handleInsufficientStorage()
+				} else {
+					this.handleSyncError(this.t('notes', 'Creating new note has failed.'))
+				}
 				throw err
 			})
 	},
@@ -103,7 +111,11 @@ export default {
 			.catch(err => {
 				store.commit('setNoteAttribute', { noteId: note.id, attribute: 'saveError', value: true })
 				console.error(err)
-				this.handleSyncError(this.t('notes', 'Updating note {id} has failed.', { id: note.id }))
+				if (err.response.status === 507) {
+					this.handleInsufficientStorage()
+				} else {
+					this.handleSyncError(this.t('notes', 'Updating note {id} has failed.', { id: note.id }))
+				}
 			})
 	},
 


### PR DESCRIPTION
- [x] roll back note creation on error (prevents repeated creation of empty notes when an error occurs while creating a new note using 3rd-party-API)
- [x] use DataResponse instead of legacy respond()
- [x] send HTTP 507 if storage is insufficient (fixes #438)