### PR TITLE
improve error handling if notes path fails

### DIFF
--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -64,7 +64,6 @@ class NotesController extends Controller {
 	 * @NoAdminRequired
 	 */
 	public function index() {
-		$notes = $this->notesService->getAll($this->userId, true);
 		$settings = $this->settingsService->getAll($this->userId);
 
 		$errorMessage = null;
@@ -74,8 +73,9 @@ class NotesController extends Controller {
 			'notesLastViewedNote'
 		);
 		// check if notes folder is accessible
+		$notes = null;
 		try {
-			$this->notesService->checkNotesFolder($this->userId);
+			$notes = $this->notesService->getAll($this->userId, true);
 			if ($lastViewedNote) {
 				// check if note exists
 				try {

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -249,15 +249,6 @@ class NotesService {
 
 	/**
 	 * @param string $userId the user id
-	 * @return boolean true if folder is accessible, or Exception otherwise
-	 */
-	public function checkNotesFolder($userId) {
-		$this->getFolderForUser($userId);
-		return true;
-	}
-
-	/**
-	 * @param string $userId the user id
 	 * @return Folder
 	 */
 	private function getFolderForUser($userId) : Folder {

--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -39,7 +39,9 @@ export default {
 			.get(this.url('/notes'))
 			.then(response => {
 				store.commit('setSettings', response.data.settings)
-				store.dispatch('addAll', response.data.notes)
+				if (response.data.notes !== null) {
+					store.dispatch('addAll', response.data.notes)
+				}
 				if (response.data.errorMessage) {
 					OC.Notification.showTemporary(response.data.errorMessage)
 				}


### PR DESCRIPTION
This gives still access to the app settings in order to set a new path, if the current path is erroneous.
Fixes #436 and fixes #429.