### PR TITLE
Category list: fix notes count

### DIFF
--- a/src/components/NavigationCategoriesItem.vue
+++ b/src/components/NavigationCategoriesItem.vue
@@ -14,7 +14,7 @@
 				icon="icon-recent"
 				@click.prevent.stop="onSelectCategory(null)"
 			>
-				<AppNavigationCounter #counter>
+				<AppNavigationCounter slot="counter">
 					{{ numNotes }}
 				</AppNavigationCounter>
 			</AppNavigationItem>
@@ -25,7 +25,7 @@
 				:icon="category.name === '' ? 'icon-emptyfolder' : 'icon-files'"
 				@click.prevent.stop="onSelectCategory(category.name)"
 			>
-				<AppNavigationCounter #counter>
+				<AppNavigationCounter slot="counter">
 					{{ category.count }}
 				</AppNavigationCounter>
 			</AppNavigationItem>


### PR DESCRIPTION
In the app-navigation's category list, the notes count was lost at some time. This brings it back.

However, I don't understand why the [Named Slots Shorthand](https://vuejs.org/v2/guide/components-slots.html#Named-Slots-Shorthand) syntax doesn't work.