### PR TITLE
auto refresh current note

### DIFF
--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -128,7 +128,11 @@ class NotesController extends Controller {
 				strval($id)
 			);
 
-			return $note->getData();
+			$result = $note->getData();
+			$etag = md5(json_encode($result));
+			return (new JSONResponse($result))
+				->setETag($etag)
+			;
 		});
 	}
 

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -33,7 +33,9 @@ export default {
 	watch: {
 		value(val) {
 			if (val !== this.mde.value()) {
+				const position = this.mde.codemirror.getCursor()
 				this.mde.value(val)
+				this.mde.codemirror.setCursor(position)
 			}
 		},
 	},

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -76,13 +76,13 @@ const mutations = {
 	updateNote(state, updated) {
 		const note = state.notesIds[updated.id]
 		if (note) {
+			note.title = updated.title
+			note.modified = updated.modified
+			note.favorite = updated.favorite
+			note.category = updated.category
 			// don't update meta-data over full data
 			if (updated.content !== undefined || note.content === undefined) {
-				note.title = updated.title
-				note.modified = updated.modified
 				note.content = updated.content
-				note.favorite = updated.favorite
-				note.category = updated.category
 				Vue.set(note, 'autotitle', updated.autotitle)
 				Vue.set(note, 'unsaved', updated.unsaved)
 				Vue.set(note, 'error', updated.error)


### PR DESCRIPTION
Fixes #310 by implementing a periodic refresh of the current note. Does not update if the note was changed locally in the meanwhile.

Please note: this does not allow collaborative editing in real-time. For this, we still have to switch the editor, see #331.
Please note also that it is still possible that concurrent changes are overwritten. However, this PR improves the situation.