### PR TITLE
debounce autotitle

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -44,6 +44,12 @@ return ['routes' => [
 		'verb' => 'POST',
 	],
 	[
+		'name' => 'notes#autotitle',
+		'url' => '/notes/{id}/autotitle',
+		'verb' => 'PUT',
+		'requirements' => ['id' => '\d+'],
+	],
+	[
 		'name' => 'notes#update',
 		'url' => '/notes/{id}',
 		'verb' => 'PUT',

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -191,14 +191,26 @@ class NotesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function update(int $id, string $content, bool $autotitle) : JSONResponse {
-		return $this->helper->handleErrorResponse(function () use ($id, $content, $autotitle) {
+	public function autotitle(int $id) : JSONResponse {
+		return $this->helper->handleErrorResponse(function () use ($id) {
+			$note = $this->notesService->get($this->helper->getUID(), $id);
+			$oldTitle = $note->getTitle();
+			$newTitle = $this->notesService->getTitleFromContent($note->getContent());
+			if ($oldTitle !== $newTitle) {
+				$note->setTitle($newTitle);
+			}
+			return $note->getTitle();
+		});
+	}
+
+
+	/**
+	 * @NoAdminRequired
+	 */
+	public function update(int $id, string $content) : JSONResponse {
+		return $this->helper->handleErrorResponse(function () use ($id, $content) {
 			$note = $this->notesService->get($this->helper->getUID(), $id);
 			$note->setContent($content);
-			if ($autotitle) {
-				$title = $this->notesService->getTitleFromContent($content);
-				$note->setTitle($title);
-			}
 			return $note->getData();
 		});
 	}

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -79,7 +79,7 @@ class NotesController extends Controller {
 						return $note->getData([ 'content' ]);
 					}
 				}, $data['notes']);
-				if ($lastViewedNote) {
+				if ($lastViewedNote && !$pruneBefore) {
 					// check if note exists
 					try {
 						$this->notesService->get($userId, $lastViewedNote);

--- a/src/App.vue
+++ b/src/App.vue
@@ -180,7 +180,9 @@ export default {
 			if (availableNotes.length > 0) {
 				this.routeToNote(availableNotes[0].id)
 			} else {
-				this.$router.push({ name: 'welcome' })
+				if (this.$route.name !== 'welcome') {
+					this.$router.push({ name: 'welcome' })
+				}
 			}
 		},
 

--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -167,7 +167,7 @@ export const createNote = category => {
 
 function _updateNote(note) {
 	return axios
-		.put(url('/notes/' + note.id), { content: note.content, autotitle: note.autotitle })
+		.put(url('/notes/' + note.id), { content: note.content })
 		.then(response => {
 			const updated = response.data
 			note.saveError = false
@@ -183,6 +183,18 @@ function _updateNote(note) {
 			store.commit('setNoteAttribute', { noteId: note.id, attribute: 'saveError', value: true })
 			console.error(err)
 			handleSyncError(t('notes', 'Saving note {id} has failed.', { id: note.id }), err)
+		})
+}
+
+export const autotitleNote = noteId => {
+	return axios
+		.put(url('/notes/' + noteId + '/autotitle'))
+		.then((response) => {
+			store.commit('setNoteAttribute', { noteId: noteId, attribute: 'title', value: response.data })
+		})
+		.catch(err => {
+			console.error(err)
+			handleSyncError(t('notes', 'Updating title for note {id} has failed.', { id: noteId }), err)
 		})
 }
 

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -63,6 +63,7 @@ import {
 import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 
+import { config } from '../config'
 import { fetchNote, refreshNote, saveNote, saveNoteManually, autotitleNote, routeIsNewNote } from '../NotesService'
 import TheEditor from './EditorEasyMDE'
 import ThePreview from './EditorMarkdownIt'
@@ -244,7 +245,7 @@ export default {
 			this.refreshTimer = setTimeout(() => {
 				this.refreshTimer = null
 				this.refreshNote()
-			}, 10000)
+			}, config.interval.note.refresh * 1000)
 		},
 
 		refreshNote() {
@@ -273,7 +274,7 @@ export default {
 					this.autosaveTimer = setTimeout(() => {
 						this.autosaveTimer = null
 						saveNote(note.id)
-					}, 2000)
+					}, config.interval.note.autosave * 1000)
 				}
 
 				// (re-) start auto refresh timer
@@ -282,21 +283,17 @@ export default {
 
 				// stop old autotitle timer
 				if (this.autotitleTimer !== null) {
-					console.debug('clear autotitle timer')
 					clearTimeout(this.autotitleTimer)
 					this.autotitleTimer = null
 				}
 				// start autotitle timer if note is new
 				if (this.isNewNote) {
-					console.debug('start autotitle timer')
 					this.autotitleTimer = setTimeout(() => {
-						console.debug('execute autotitle timer')
 						this.autotitleTimer = null
 						if (this.isNewNote) {
-							console.debug('autotitle note')
 							autotitleNote(note.id)
 						}
-					}, 5000)
+					}, config.interval.note.autotitle * 1000)
 				}
 			}
 		},

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -20,19 +20,12 @@
 					>
 						{{ t('notes', 'Details') }}
 					</ActionButton>
-					<ActionButton v-if="!preview"
-						icon="icon-toggle"
+					<ActionButton
 						v-tooltip.left="t('notes', 'CTRL + /')"
+						:icon="preview ? 'icon-rename' : 'icon-toggle'"
 						@click="onTogglePreview"
 					>
-						{{ t('notes', 'Preview') }}
-					</ActionButton>
-					<ActionButton v-else
-						icon="icon-rename"
-						v-tooltip.left="t('notes', 'CTRL + /')"
-						@click="onTogglePreview"
-					>
-						{{ t('notes', 'Edit') }}
+						{{ preview ? t('notes', 'Edit') : t('notes', 'Preview') }}
 					</ActionButton>
 					<ActionButton
 						icon="icon-fullscreen"
@@ -317,7 +310,7 @@ export default {
 			const note = {
 				...this.note,
 			}
-			store.commit('add', note)
+			store.commit('updateNote', note)
 			saveNoteManually(this.note.id)
 		},
 	},

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,9 @@
+export const config = {
+	interval: {
+		note: {
+			autosave: 1,
+			autotitle: 2,
+			refresh: 10,
+		},
+	},
+}

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -83,7 +83,6 @@ const mutations = {
 			// don't update meta-data over full data
 			if (updated.content !== undefined || note.content === undefined) {
 				note.content = updated.content
-				Vue.set(note, 'autotitle', updated.autotitle)
 				Vue.set(note, 'unsaved', updated.unsaved)
 				Vue.set(note, 'error', updated.error)
 				Vue.set(note, 'errorMessage', updated.errorMessage)


### PR DESCRIPTION
For new notes, the title is automatically changed. This PR debounces the title generation from saving the content. Therefore, a timer is set that generates a new title after ~~5 seconds~~ 2 seconds after the last typing in that note.

fixes #489