### PR TITLE
fix(Notes Dashboard Widget): avoid HTTP 500 due mid-UTF8 excerpt truncation

### DIFF
--- a/lib/Service/Note.php
+++ b/lib/Service/Note.php
@@ -64,12 +64,12 @@ class Note {
 		if (!empty($title)) {
 			$length = strlen($title);
 			if (strncasecmp($excerpt, $title, $length) === 0) {
-				$excerpt = substr($excerpt, $length);
+				$excerpt = mb_substr($excerpt, $length, null, "utf-8");
 			}
 		}
 		$excerpt = trim($excerpt);
 		if (strlen($excerpt) > $maxlen) {
-			$excerpt = substr($excerpt, 0, $maxlen) . '…';
+			$excerpt = mb_substr($excerpt, 0, $maxlen, "utf-8") . '…';
 		}
 		return str_replace("\n", "\u{2003}", $excerpt);
 	}

--- a/lib/Service/Note.php
+++ b/lib/Service/Note.php
@@ -62,13 +62,13 @@ class Note {
 		$excerpt = trim($this->noteUtil->stripMarkdown($this->getContent()));
 		$title = $this->getTitle();
 		if (!empty($title)) {
-			$length = strlen($title);
+			$length = mb_strlen($title, "utf-8");
 			if (strncasecmp($excerpt, $title, $length) === 0) {
 				$excerpt = mb_substr($excerpt, $length, null, "utf-8");
 			}
 		}
 		$excerpt = trim($excerpt);
-		if (strlen($excerpt) > $maxlen) {
+		if (mb_strlen($excerpt, "utf-8") > $maxlen) {
 			$excerpt = mb_substr($excerpt, 0, $maxlen, "utf-8") . '…';
 		}
 		return str_replace("\n", "\u{2003}", $excerpt);


### PR DESCRIPTION
Fix courtesty due to @D-side

This issue occurs when 100 bytes past the start of the note is inside
a UTF-8 multibyte character. E. g. if a note is comprised of 99
single-bytes and 100th multibyte.

This is very easy to hit in Russian, since it uses a Cyrillic charset
(2 bytes per UTF-8 char), but spaces and punctuation from ASCII
(1 byte each). But since the condition is so obscure, some texts
work and some don't seemingly at random (except not!).

Based on https://stackoverflow.com/q/9087502/ it seems that
using  `mb_substr` with `utf-8` seems to be the better approach