### PR TITLE
Improve handling of files with special chars

### DIFF
--- a/lib/Service/Note.php
+++ b/lib/Service/Note.php
@@ -49,8 +49,12 @@ class Note {
 			throw new \Exception('Can\'t read file content for '.$this->file->getPath());
 		}
 		if (!mb_check_encoding($content, 'UTF-8')) {
+			$this->util->logger->warning(
+				'File encoding for '.$this->file->getPath().' is not UTF-8. This may cause problems.'
+			);
 			$content = mb_convert_encoding($content, 'UTF-8');
 		}
+		$content = str_replace([ pack('H*', 'FEFF'), pack('H*', 'FFEF'), pack('H*', 'EFBBBF') ], '', $content);
 		return $content;
 	}
 

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -94,6 +94,9 @@ class NoteUtil {
 		$splitContent = preg_split("/\R/u", $content, 2);
 		$title = trim($splitContent[0]);
 
+		// replace (Unicode) white-space with normal space
+		$title = preg_replace('/\s/u', ' ', $title);
+
 		// using a maximum of 100 chars should be enough
 		$title = mb_substr($title, 0, 100, "UTF-8");
 
@@ -123,7 +126,7 @@ class NoteUtil {
 		}
 
 		// prevent file to be hidden
-		$str = preg_replace("/^[\. ]+/mu", "", $str);
+		$str = preg_replace('/^[\.\s]+/mu', '', $str);
 		return trim($str);
 	}
 


### PR DESCRIPTION
Remove BOM, tabs and other (Unicode) white-spaces from title, before renaming a note. Fixes #623

Warn if a file is not UTF-8. Maybe this will be an exception in a future version of the app.