### PR TITLE
Integrate Nextcloud Text as editor for notes

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -6,10 +6,13 @@ namespace OCA\Notes\Controller;
 
 use OCA\Notes\Service\NotesService;
 
+use OCA\Viewer\Event\LoadViewer;
+
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
@@ -19,6 +22,8 @@ class PageController extends Controller {
 	private $notesService;
 	/** @var IUserSession */
 	private $userSession;
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
 	/** @IURLGenerator */
 	private $urlGenerator;
 
@@ -27,11 +32,13 @@ class PageController extends Controller {
 		IRequest $request,
 		NotesService $notesService,
 		IUserSession $userSession,
+		IEventDispatcher $eventDispatcher,
 		IURLGenerator $urlGenerator
 	) {
 		parent::__construct($AppName, $request);
 		$this->notesService = $notesService;
 		$this->userSession = $userSession;
+		$this->eventDispatcher = $eventDispatcher;
 		$this->urlGenerator = $urlGenerator;
 	}
 
@@ -41,6 +48,7 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	public function index() : TemplateResponse {
+		$this->eventDispatcher->dispatch(LoadViewer::class, new LoadViewer());
 		$devMode = !is_file(dirname(__FILE__).'/../../js/notes-main.js');
 		$response = new TemplateResponse(
 			$this->appName,


### PR DESCRIPTION
Currently, this is just a proof-of-concept. See #331 for more information.

## Screenshots
### Before: Edit mode
![Screenshot](https://user-images.githubusercontent.com/6277619/103178294-d6673080-4881-11eb-8626-dd036c282771.png)

### Before: Preview mode
![Screenshot](https://user-images.githubusercontent.com/6277619/103178302-ea129700-4881-11eb-8a75-47654bacf004.png)

### After: WYSIWYG edit mode (replaces old edit mode and old preview mode)
![Screenshot](https://user-images.githubusercontent.com/6277619/103178313-09112900-4882-11eb-98df-bfc3c2ba08a6.png)

## Open Tasks
regarding Notes app
- [ ] remember last opened note
- [ ] auto title for new notes

regarding Text app
- [ ] don't break original file, see https://github.com/nextcloud/text/issues/593 and https://github.com/nextcloud/text/issues/772
- [ ] improve parallel changes from outside of app, see https://github.com/nextcloud/text/issues/1212
- [ ] use correct / other list/task syntax, see https://github.com/nextcloud/text/issues/1297

regarding Text integration in Notes app
- [ ] loading another note with same component (proof-of-concept uses a "hack" which does not allow for a loading indicator)
- [ ] "Link file" feature of the Text app could be replaced by a "Link note" feature (?)
- [ ] how to provide integrated images to 3rd-party apps using the Notes API?