### PR TITLE
remove "more" entry from dashboard

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,8 +1,6 @@
 <template>
 	<DashboardWidget :items="items"
 		:loading="loading"
-		:show-more-text="t('notes', 'notes')"
-		:show-more-url="showMoreUrl"
 	>
 		<template #default="{ item }">
 			<DashboardWidgetItem


### PR DESCRIPTION
remove "more" entry from dashboard, since its translation doesn't work and no other app uses it.