### PR TITLE
Prevent lost updates by using ETags for notes

### DIFF
--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -91,9 +91,11 @@ No valid authentication credentials supplied.
 | Parameter | Type | Description |
 |:------|:-----|:-----|
 | `id` | integer, required (path) | ID of the note to query. |
+| `If-None-Match` | HTTP header, optional | Use this in order to reduce transferred data size (see [HTTP ETag](https://en.wikipedia.org/wiki/HTTP_ETag)). You should use the value from the note's attribute `etag` or from the last request's HTTP response header `ETag`. | 1.2 |
 
 #### Response
 ##### 200 OK
+- **HTTP Header**: `ETag` (see [HTTP ETag](https://en.wikipedia.org/wiki/HTTP_ETag)). The value is identical to the note's attribute `etag` (see section [Note attributes](#note-attributes)).
 - **Body**: note (see section [Note attributes](#note-attributes)), example:
 ```js
 {

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -20,7 +20,7 @@ The app and the API is mainly about notes. So, let's have a look about the attri
 | Attribute | Type | Description | since API version |
 |:----------|:-----|:-------------------------|:-------------------|
 | `id` | integer (read‑only) | Every note has a unique identifier which is created by the server. It can be used to query and update a specific note. | 1.0 |
-| `etag` | string (read‑only) | The note's entity tag (ETag) indicates if a note's attribute has changed. I.e., if the note changes, the ETag changes, too. Clients can use the ETag for detecting if the local note has to be updated from server and for [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control). | 1.2 |
+| `etag` | string (read‑only) | The note's entity tag (ETag) indicates if a note's attribute has changed. I.e., if the note changes, the ETag changes, too. Clients can use the ETag for detecting if the local note has to be updated from server and for optimistic concurrency control (see section [Preventing lost updates and conflict solution](#preventing-lost-updates-and-conflict-solution)). | 1.2 |
 | `content` | string (read/write) | Notes can contain arbitrary text. Formatting should be done using Markdown, but not every markup can be supported by every client. Therefore, markup should be used with care. | 1.0 |
 | `title` | string (read/write) | The note's title is also used as filename for the note's file. Therefore, some special characters are automatically removed and a sequential number is added if a note with the same title in the same category exists. When saving a title, the sanitized value is returned and should be adopted by your client. | 1.0 |
 | `category` | string (read/write) | Every note is assigned to a category. By default, the category is an empty string (not null), which means the note is uncategorized. Categories are mapped to folders in the file backend. Illegal characters are automatically removed and the respective folder is automatically created. Sub-categories (mapped to sub-folders) can be created by using `/` as delimiter. | 1.0 |
@@ -152,6 +152,7 @@ Not enough free storage for saving the note's content.
 | Parameter | Type | Description |
 |:------|:-----|:-----|
 | `id` | integer, required (path) | ID of the note to update. |
+| `If-Match` | HTTP header, optional | Use this for optimistic concurrency control (optional, but strongly recommended in order to prevent lost updates). As value of this HTTP header, the client has to use the last known note's etag (see section [Note attributes](#note-attributes)). If the note has changed in the meanwhile (concurrent change), the update request is blocked with HTTP status 412 (see below). Otherwise, the request will be processed normally. | 1.2 |
 - **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example see section [Create note](#create-note-post-notes).
 
 #### Response
@@ -166,6 +167,11 @@ No valid authentication credentials supplied.
 
 ##### 404 Not Found
 Note not found.
+
+##### 412 Precondition Failed
+*(since API v1.2)*
+Update cannot be performed since the note has been changed on the server in the meanwhile (concurrent change). The body contains the current note's state from server (see section [Note attributes](#note-attributes)), example see section [Get single note](#get-single-note-get-notesid). The client should use this response data in order to perform a conflict solution (see section [Preventing lost updates and conflict solution](#preventing-lost-updates-and-conflict-solution)).
+
 
 ##### 507 Insufficient Storage
 Not enough free storage for saving the note's content.
@@ -249,3 +255,26 @@ Endpoint not supported by installed notes app version (requires API version 1.2)
 ##### 401 Unauthorized
 No valid authentication credentials supplied.
 </details>
+
+
+
+## Preventing lost updates and conflict solution
+
+While changing a note using a Notes client, the same note may be changed by another client.
+In order to prevent lost updates of those concurrent changes, the notes API uses a well established mechanism called [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control).
+For this purpose, notes have the attribute `etag` which is an identifier that changes if (and only if) the note changes on the server.
+Clients have to store the `etag` for every note and send its value with every update request (HTTP header `If-Match`, see section [Update note](#update-note-put-notesid)).
+If there was no parallel change on the server (i.e., the `etag` on server is the same as the one send from the client), the update request is performed as usual.
+But if there was a parallel change, the `etag` on the server has changed and the server will refuse the update request.
+
+In this case, the client has to perform a conflict resolution, i.e. the local changes have to be merged with the remote changes.
+In order to compare local changes with remote changes, it is useful that the client stores the full note's state as reference state before performing any local updates.
+If an update conflict occurs, the client can use this reference state in order to merge all changes attribute-wise:
+- Attributes, that have changed only locally or remotely, can be merged by picking the (local resp. remote) change.
+- Attributes, that have changed both localy and remotely, have to be merged (see below).
+
+There are several options on how to merge an attribute:
+- a) *Let the user decide*: ask the user whether i) overwrite local changes, ii) overwrite remote changes, or iii) save local (or remote) changes as new note.
+- b) *Let the user merge*: provide an interface which allows for merging the files (you know it from your version control).
+- c) *Try to merge automatically*: merge all changes automatically, e.g. for the `content` attribute using the [google-diff-match-patch](https://code.google.com/p/google-diff-match-patch/) ([Demo](https://neil.fraser.name/software/diff_match_patch/svn/trunk/demos/demo_patch.html), [Code](https://github.com/bystep15/google-diff-match-patch)) library.
+

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -19,12 +19,13 @@ The app and the API is mainly about notes. So, let's have a look about the attri
 
 | Attribute | Type | Description | since API version |
 |:----------|:-----|:-------------------------|:-------------------|
-| `id` | integer | Every note has a unique identifier which is created by the server. It can be used to query and update a specific note. | 1.0 |
-| `content` | string | Notes can contain arbitrary text. Formatting should be done using Markdown, but not every markup can be supported by every client. Therefore, markup should be used with care. | 1.0 |
-| `title` | string | The note's title is also used as filename for the note's file. Therefore, some special characters are automatically removed and a sequential number is added if a note with the same title in the same category exists. When saving a title, the sanitized value is returned and should be adopted by your client. | 1.0 |
-| `category` | string | Every note is assigned to a category. By default, the category is an empty string (not null), which means the note is uncategorized. Categories are mapped to folders in the file backend. Illegal characters are automatically removed and the respective folder is automatically created. Sub-categories (mapped to sub-folders) can be created by using `/` as delimiter. | 1.0 |
-| `favorite` | boolean | If a note is marked as favorite, it is displayed at the top of the notes' list. Default is `false`. | 1.0 |
-| `modified` | integer | Unix timestamp for the last modified date/time of the note. If not provided on note creation or content update, the current time is used. | 1.0 |
+| `id` | integer (read‑only) | Every note has a unique identifier which is created by the server. It can be used to query and update a specific note. | 1.0 |
+| `etag` | string (read‑only) | The note's entity tag (ETag) indicates if a note's attribute has changed. I.e., if the note changes, the ETag changes, too. Clients can use the ETag for detecting if the local note has to be updated from server and for [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control). | 1.2 |
+| `content` | string (read/write) | Notes can contain arbitrary text. Formatting should be done using Markdown, but not every markup can be supported by every client. Therefore, markup should be used with care. | 1.0 |
+| `title` | string (read/write) | The note's title is also used as filename for the note's file. Therefore, some special characters are automatically removed and a sequential number is added if a note with the same title in the same category exists. When saving a title, the sanitized value is returned and should be adopted by your client. | 1.0 |
+| `category` | string (read/write) | Every note is assigned to a category. By default, the category is an empty string (not null), which means the note is uncategorized. Categories are mapped to folders in the file backend. Illegal characters are automatically removed and the respective folder is automatically created. Sub-categories (mapped to sub-folders) can be created by using `/` as delimiter. | 1.0 |
+| `favorite` | boolean (read/write) | If a note is marked as favorite, it is displayed at the top of the notes' list. Default is `false`. | 1.0 |
+| `modified` | integer (read/write) | Unix timestamp for the last modified date/time of the note. If not provided on note creation or content update, the current time is used. | 1.0 |
 
 
 ## Settings
@@ -68,6 +69,7 @@ All defined routes in the specification are appended to this url. To access all 
 [
     {
         "id": 76,
+        "etag": "be284e00488c61c101ee28309d235e0b",
         "modified": 1376753464,
         "title": "New note",
         "category": "sub-directory",
@@ -96,6 +98,7 @@ No valid authentication credentials supplied.
 ```js
 {
     "id": 76,
+    "etag": "be284e00488c61c101ee28309d235e0b",
     "modified": 1376753464,
     "title": "New note",
     "category": "sub-directory",
@@ -118,7 +121,7 @@ Note not found.
 <details><summary>Details</summary>
 
 #### Request parameters
-- **Body**: See section [Note attributes](#note-attributes) (except for `id`).  All attributes are optional. Example: 
+- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example: 
 ```js
 {
     "title": "New note",
@@ -149,7 +152,7 @@ Not enough free storage for saving the note's content.
 | Parameter | Type | Description |
 |:------|:-----|:-----|
 | `id` | integer, required (path) | ID of the note to update. |
-- **Body**: See section [Note attributes](#note-attributes) (except for `id`).  All attributes are optional. Example see section [Create note](#create-note-post-notes).
+- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example see section [Create note](#create-note-post-notes).
 
 #### Response
 ##### 200 OK

--- a/lib/Controller/ETagDoesNotMatchException.php
+++ b/lib/Controller/ETagDoesNotMatchException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Notes\Controller;
+
+use OCA\Notes\Service\Note;
+
+use Exception;
+
+class ETagDoesNotMatchException extends Exception {
+	public $note;
+
+	public function __construct(Note $note) {
+		$this->note = $note;
+	}
+}

--- a/lib/Controller/Helper.php
+++ b/lib/Controller/Helper.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace OCA\Notes\Controller;
 
 use OCA\Notes\AppInfo\Application;
+use OCA\Notes\Db\Meta;
+use OCA\Notes\Service\Note;
+use OCA\Notes\Service\NotesService;
+use OCA\Notes\Service\MetaService;
 use OCA\Notes\Service\Util;
 
 use OCP\AppFramework\Http;
@@ -15,21 +19,66 @@ use Psr\Log\LoggerInterface;
 
 class Helper {
 
+	/** @var NotesService */
+	private $notesService;
+	/** @var MetaService */
+	private $metaService;
 	/** @var LoggerInterface */
 	public $logger;
 	/** @var IUserSession */
 	private $userSession;
 
 	public function __construct(
+		NotesService $notesService,
+		MetaService $metaService,
 		IUserSession $userSession,
 		LoggerInterface $logger
 	) {
+		$this->notesService = $notesService;
+		$this->metaService = $metaService;
 		$this->userSession = $userSession;
 		$this->logger = $logger;
 	}
 
 	public function getUID() : string {
 		return $this->userSession->getUser()->getUID();
+	}
+
+	public function getNoteData(Note $note, array $exclude = [], Meta $meta = null) : array {
+		if ($meta === null) {
+			$meta = $this->metaService->update($this->getUID(), $note);
+		}
+		$data = $note->getData($exclude);
+		$data['etag'] = $meta->getEtag();
+		return $data;
+	}
+
+	public function getNotesAndCategories(
+		int $pruneBefore,
+		array $exclude,
+		string $category = null
+	) : array {
+		$userId = $this->getUID();
+		$data = $this->notesService->getAll($userId);
+		$notes = $data['notes'];
+		$metas = $this->metaService->updateAll($userId, $notes);
+		if ($category !== null) {
+			$notes = array_values(array_filter($notes, function ($note) use ($category) {
+				return $note->getCategory() === $category;
+			}));
+		}
+		$notesData = array_map(function ($note) use ($metas, $pruneBefore, $exclude) {
+			$meta = $metas[$note->getId()];
+			if ($pruneBefore && $meta->getLastUpdate() < $pruneBefore) {
+				return [ 'id' => $note->getId() ];
+			} else {
+				return $this->getNoteData($note, $exclude, $meta);
+			}
+		}, $notes);
+		return [
+			'notes' => $notesData,
+			'categories' => $data['categories'],
+		];
 	}
 
 	public function logException(\Throwable $e) : void {

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -68,7 +68,10 @@ class NotesApiController extends ApiController {
 		return $this->helper->handleErrorResponse(function () use ($id, $exclude) {
 			$exclude = explode(',', $exclude);
 			$note = $this->service->get($this->helper->getUID(), $id);
-			return $this->helper->getNoteData($note, $exclude);
+			$noteData = $this->helper->getNoteData($note, $exclude);
+			return (new JSONResponse($noteData))
+				->setETag($noteData['etag'])
+			;
 		});
 	}
 

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -143,7 +143,7 @@ class NotesApiController extends ApiController {
 			$category,
 			$favorite
 		) {
-			$note = $this->service->get($this->helper->getUID(), $id);
+			$note = $this->helper->getNoteWithETagCheck($id, $this->request);
 			if ($content !== null) {
 				$note->setContent($content);
 			}

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -222,7 +222,7 @@ class NotesController extends Controller {
 	 */
 	public function update(int $id, string $content) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id, $content) {
-			$note = $this->notesService->get($this->helper->getUID(), $id);
+			$note = $this->helper->getNoteWithETagCheck($id, $this->request);
 			$note->setContent($content);
 			return $this->helper->getNoteData($note);
 		});

--- a/lib/Service/MetaService.php
+++ b/lib/Service/MetaService.php
@@ -92,17 +92,18 @@ class MetaService {
 		return $metas;
 	}
 
-	public function update(string $userId, Note $note) : void {
+	public function update(string $userId, Note $note) : Meta {
 		$meta = null;
 		try {
 			$meta = $this->metaMapper->findById($userId, $note->getId());
 		} catch (\OCP\AppFramework\Db\DoesNotExistException $e) {
 		}
 		if ($meta === null) {
-			$this->createMeta($userId, $note);
+			$meta = $this->createMeta($userId, $note);
 		} elseif ($this->updateIfNeeded($meta, $note, true)) {
 			$this->metaMapper->update($meta);
 		}
+		return $meta;
 	}
 
 	private function getIndexedArray(array $data, string $property) : array {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5029,6 +5029,19 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
+		"node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -14815,6 +14828,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,13 @@
 				"@nextcloud/vue": "^3.8.0",
 				"@nextcloud/vue-dashboard": "^2.0.0",
 				"@nextcloud/webpack-vue-config": "^4.0.1",
+				"diff": "^5.0.0",
 				"easymde": "^2.14.0",
 				"markdown-it": "^12.0.4",
 				"stylelint-webpack-plugin": "^2.1.1",
 				"vue": "^2.6.12",
 				"vue-fragment": "1.5.1",
+				"vue-material-design-icons": "^4.11.0",
 				"vue-observe-visibility": "^1.0.0",
 				"vue-router": "^3.5.1",
 				"vuex": "^3.6.2"
@@ -3492,6 +3494,14 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -5018,19 +5028,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
@@ -10511,6 +10508,11 @@
 				}
 			}
 		},
+		"node_modules/vue-material-design-icons": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-4.11.0.tgz",
+			"integrity": "sha512-3Tyeqi9jtONQ/x8WkJqiBs4t5Bd5O1t7RdM/GIPKVYoVdaRy0oy3nbRjnMGyONBlqC/NpPjzhWeoZWUMEI04nA=="
+		},
 		"node_modules/vue-multiselect": {
 			"version": "2.1.6",
 			"resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
@@ -13668,6 +13670,11 @@
 				"minimalistic-assert": "^1.0.0"
 			}
 		},
+		"diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+		},
 		"diffie-hellman": {
 			"version": "5.0.3",
 			"resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -14808,12 +14815,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -18903,6 +18904,11 @@
 				"vue-hot-reload-api": "^2.3.0",
 				"vue-style-loader": "^4.1.0"
 			}
+		},
+		"vue-material-design-icons": {
+			"version": "4.11.0",
+			"resolved": "https://registry.npmjs.org/vue-material-design-icons/-/vue-material-design-icons-4.11.0.tgz",
+			"integrity": "sha512-3Tyeqi9jtONQ/x8WkJqiBs4t5Bd5O1t7RdM/GIPKVYoVdaRy0oy3nbRjnMGyONBlqC/NpPjzhWeoZWUMEI04nA=="
 		},
 		"vue-multiselect": {
 			"version": "2.1.6",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,13 @@
 		"@nextcloud/vue": "^3.8.0",
 		"@nextcloud/vue-dashboard": "^2.0.0",
 		"@nextcloud/webpack-vue-config": "^4.0.1",
+		"diff": "^5.0.0",
 		"easymde": "^2.14.0",
 		"markdown-it": "^12.0.4",
 		"stylelint-webpack-plugin": "^2.1.1",
 		"vue": "^2.6.12",
 		"vue-fragment": "1.5.1",
+		"vue-material-design-icons": "^4.11.0",
 		"vue-observe-visibility": "^1.0.0",
 		"vue-router": "^3.5.1",
 		"vuex": "^3.6.2"

--- a/src/Util.js
+++ b/src/Util.js
@@ -1,0 +1,21 @@
+export const noteAttributes = [
+	'id',
+	'etag',
+	'title',
+	'content',
+	'modified',
+	'favorite',
+	'category',
+]
+
+export const copyNote = (from, to, exclude) => {
+	if (exclude === undefined) {
+		exclude = []
+	}
+	noteAttributes.forEach(attr => {
+		if (!exclude.includes(attr)) {
+			to[attr] = from[attr]
+		}
+	})
+	return to
+}

--- a/src/components/ConflictSolution.vue
+++ b/src/components/ConflictSolution.vue
@@ -1,0 +1,94 @@
+<template>
+	<div class="conflict-solution">
+		<div class="text">
+			<pre v-for="(l, i) in diff" :key="i" :class="l.className">{{ l.line }}</pre>
+		</div>
+		<button @click="$emit('onChooseSolution')">
+			{{ button }}
+		</button>
+	</div>
+</template>
+<script>
+
+import { diffLines } from 'diff'
+
+export default {
+	name: 'ConflictSolution',
+
+	props: {
+		content: {
+			type: String,
+			required: true,
+		},
+		reference: {
+			type: String,
+			required: true,
+		},
+		button: {
+			type: String,
+			required: true,
+		},
+	},
+
+	computed: {
+		diff() {
+			const diffs = diffLines(this.reference, this.content)
+			const line2class = function(line) {
+				if (line.added) {
+					return 'added'
+				} else if (line.removed) {
+					return 'removed'
+				} else {
+					return 'unchanged'
+				}
+			}
+			const lines = []
+			diffs.forEach(diff => {
+				const className = line2class(diff)
+				diff.value.replace(/\r?\n$/, '').split(/\r?\n/).forEach(line => {
+					lines.push({ line, className })
+				})
+			})
+			return lines
+		},
+	},
+}
+</script>
+<style scoped>
+.conflict-solution {
+	height: 100%;
+	padding: 1ex;
+	margin: 1ex;
+	flex: 1;
+}
+
+.conflict-solution .text {
+	max-height: 60vh;
+	overflow: auto;
+	background-color: var(--color-background-darker);
+	padding: 0 1ex;
+}
+
+.conflict-solution .text pre {
+	white-space: pre-wrap;
+	line-height: 1.2;
+	padding: 0.3ex 0.5ex;
+}
+
+.conflict-solution .text .removed {
+	background-color: rgba(128, 128, 128, 0.2);
+	color: rgba(128, 128, 128, 1);
+	text-decoration: line-through;
+}
+
+.conflict-solution .text .added {
+	background-color: rgba(70, 186, 97, 0.2);
+	color: rgba(70, 186, 97, 1);
+}
+
+.conflict-solution button {
+	margin: auto;
+	margin-top: 2ex;
+	display: block;
+}
+</style>

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -1,4 +1,5 @@
 import Vue from 'vue'
+import { copyNote } from '../Util'
 
 const state = {
 	categories: [],
@@ -76,13 +77,11 @@ const mutations = {
 	updateNote(state, updated) {
 		const note = state.notesIds[updated.id]
 		if (note) {
-			note.title = updated.title
-			note.modified = updated.modified
-			note.favorite = updated.favorite
-			note.category = updated.category
+			copyNote(updated, note, ['id', 'etag', 'content'])
 			// don't update meta-data over full data
-			if (updated.content !== undefined || note.content === undefined) {
+			if (updated.content !== undefined && updated.etag !== undefined) {
 				note.content = updated.content
+				note.etag = updated.etag
 				Vue.set(note, 'unsaved', updated.unsaved)
 				Vue.set(note, 'error', updated.error)
 				Vue.set(note, 'errorMessage', updated.errorMessage)

--- a/tests/api/AbstractAPITest.php
+++ b/tests/api/AbstractAPITest.php
@@ -188,9 +188,19 @@ abstract class AbstractAPITest extends TestCase {
 		return $note;
 	}
 
-	protected function updateNote(\stdClass &$note, \stdClass $request, \stdClass $expected) {
-		$response = $this->http->request('PUT', 'notes/'.$note->id, [ 'json' => $request ]);
-		$this->checkResponse($response, 'Update note '.$note->title, 200);
+	protected function updateNote(
+		\stdClass &$note,
+		\stdClass $request,
+		\stdClass $expected,
+		string $etag = null,
+		int $statusExp = 200
+	) {
+		$requestOptions = [ 'json' => $request ];
+		if ($etag !== null) {
+			$requestOptions['headers'] = [ 'If-Match' => '"'.$etag.'"' ];
+		}
+		$response = $this->http->request('PUT', 'notes/'.$note->id, $requestOptions);
+		$this->checkResponse($response, 'Update note '.$note->title, $statusExp);
 		$responseNote = json_decode($response->getBody()->getContents());
 		foreach (get_object_vars($request) as $key => $val) {
 			$note->$key = $val;

--- a/tests/api/AbstractAPITest.php
+++ b/tests/api/AbstractAPITest.php
@@ -199,6 +199,7 @@ abstract class AbstractAPITest extends TestCase {
 			$note->$key = $val;
 		}
 		$this->checkReferenceNote($note, $responseNote, 'Updated note');
+		return $responseNote;
 	}
 
 	protected function checkObject(

--- a/tests/api/CommonAPITest.php
+++ b/tests/api/CommonAPITest.php
@@ -12,6 +12,7 @@ abstract class CommonAPITest extends AbstractAPITest {
 		'category' => 'string',
 		'modified' => 'integer',
 		'favorite' => 'boolean',
+		'etag' => 'string',
 	];
 
 	private $requiredSettings = [
@@ -184,7 +185,7 @@ abstract class CommonAPITest extends AbstractAPITest {
 		$this->checkGetReferenceNotes(array_merge($refNotes, $testNotes), 'Pre-condition');
 		$note = $testNotes[0];
 		// test update note with all attributes
-		$this->updateNote($note, (object)[
+		$rn1 = $this->updateNote($note, (object)[
 			'title' => 'First *manual* edited title',
 			'content' => '# *First* edited/ note'.PHP_EOL.'This is some body content with some data.',
 			'favorite' => false,
@@ -194,19 +195,22 @@ abstract class CommonAPITest extends AbstractAPITest {
 			'title' => $this->autotitle ? 'First edited note' : 'First manual edited title',
 		]);
 		// test update note with single attributes
-		$this->updateNote($note, (object)[
+		$rn2 = $this->updateNote($note, (object)[
 			'category' => 'Test/Third Category',
 		], (object)[]);
 		// TODO test update category with read-only folder (target category)
-		$this->updateNote($note, (object)[
+		$rn3 = $this->updateNote($note, (object)[
 			'favorite' => true,
 		], (object)[]);
-		$this->updateNote($note, (object)[
+		$rn4 = $this->updateNote($note, (object)[
 			'content' => '# First multi edited note'.PHP_EOL.'This is some body content with some data.',
 		], (object)[
 			'title' => $this->autotitle ? 'First multi edited note' : 'First manual edited title',
 			'modified' => time(),
 		]);
+		$this->assertNotEquals($rn1->etag, $rn2->etag, 'ETag changed on update (1)');
+		$this->assertNotEquals($rn2->etag, $rn3->etag, 'ETag changed on update (2)');
+		$this->assertNotEquals($rn3->etag, $rn4->etag, 'ETag changed on update (3)');
 		$this->checkGetReferenceNotes(array_merge($refNotes, $testNotes), 'After updating notes');
 		return $testNotes;
 	}

--- a/tests/api/CommonAPITest.php
+++ b/tests/api/CommonAPITest.php
@@ -197,7 +197,13 @@ abstract class CommonAPITest extends AbstractAPITest {
 		// test update note with single attributes
 		$rn2 = $this->updateNote($note, (object)[
 			'category' => 'Test/Third Category',
-		], (object)[]);
+		], (object)[], $rn1->etag);
+		// test update note with wrong ETag
+		$this->updateNote($note, (object)[
+			'category' => 'New Fail',
+		], (object)[
+			'category' => 'Test/Third Category',
+		], 'wrongetag', 412);
 		// TODO test update category with read-only folder (target category)
 		$rn3 = $this->updateNote($note, (object)[
 			'favorite' => true,


### PR DESCRIPTION
Finally, I've implemented ETags for notes / If-Match HTTP header for the notes API. This fixes #56.

Includes:
- [x] API: expose the note's ETag and check note's ETag on update request (HTTP If-Match / 412) => new minor API version 1.2
- [x] documentation for API changes
- [x] Test cases
- [x] web-frontend: check for update conflicts and provide solutions

@stefan-niedermann @phedlund : Please have a look if you see any problems with these changes. They are downwards-compatible, so you don't need to change your implementation. However, it is strongly recommended in order to prevent lost updates. If you implement it, your implementation is still compatible with older (server) Notes app versions, since they just ignore the `If-Match` header.