### PR TITLE
new Settings API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ app_name=notes
 project_dir=$(CURDIR)/../$(app_name)
 build_dir=$(CURDIR)/build/artifacts
 cert_dir=$(HOME)/.nextcloud/certificates
+php_dirs=appinfo/ lib/ tests/api/
 
 
 all: dev-setup build
@@ -99,7 +100,7 @@ lint-phpfast: lint-php-lint lint-php-ncversion lint-php-cs-fixer lint-php-phpcs
 
 lint-php-lint:
 	# Check PHP syntax errors
-	@! find lib/ -name "*.php" | xargs -I{} php -l '{}' | grep -v "No syntax errors detected"
+	@! find $(php_dirs) -name "*.php" | xargs -I{} php -l '{}' | grep -v "No syntax errors detected"
 
 lint-php-ncversion:
 	# Check min-version consistency
@@ -111,7 +112,7 @@ lint-php-phan:
 
 lint-php-phpcs:
 	# PHP CodeSniffer
-	vendor/bin/phpcs --standard=tests/phpcs.xml appinfo/ lib/ tests/api/ --report=checkstyle | vendor/bin/cs2pr --graceful-warnings --colorize
+	vendor/bin/phpcs --standard=tests/phpcs.xml $(php_dirs) --report=checkstyle | vendor/bin/cs2pr --graceful-warnings --colorize
 
 lint-php-cs-fixer:
 	# PHP Coding Standards Fixer (with Nextcloud coding standards)
@@ -136,7 +137,7 @@ lint-xml:
 lint-fix: lint-php-fix lint-js-fix lint-css-fix
 
 lint-php-fix:
-	vendor/bin/phpcbf --standard=tests/phpcs.xml appinfo/ lib/ tests/api/
+	vendor/bin/phpcbf --standard=tests/phpcs.xml $(php_dirs)
 	vendor/bin/php-cs-fixer fix
 
 lint-js-fix:

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -151,6 +151,22 @@ return ['routes' => [
 		],
 	],
 	[
+		'name' => 'notes_api#setSettings',
+		'url' => '/api/{apiVersion}/settings',
+		'verb' => 'PUT',
+		'requirements' => [
+			'apiVersion' => '(v1)',
+		],
+	],
+	[
+		'name' => 'notes_api#getSettings',
+		'url' => '/api/{apiVersion}/settings',
+		'verb' => 'GET',
+		'requirements' => [
+			'apiVersion' => '(v1)',
+		],
+	],
+	[
 		'name' => 'notes_api#fail',
 		'url' => '/api/{catchAll}',
 		'verb' => 'GET',

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -27,6 +27,16 @@ The app and the API is mainly about notes. So, let's have a look about the attri
 | `modified` | integer | Unix timestamp for the last modified date/time of the note. If not provided on note creation or content update, the current time is used. | 1.0 |
 
 
+## Settings
+
+Since API version 1.2, it is possible to change app settings using the API. The following settings attributes exist:
+
+| Attribute | Type | Description | since API version |
+|:----------|:-----|:------------|:------------------|
+| `notesPath` | string | Path to the folder, where note's files are stored in Nextcloud. The path must be relative to the user folder. Default is the localized string `Notes`. | 1.2 |
+| `fileSuffix` | string | Newly created note's files will have this file suffix. Only the values `.txt` or `.md` are allowed. Default is `.txt`. | 1.2 |
+
+
 ## Endpoints and Operations
 
 The base URL for all calls is:
@@ -179,4 +189,60 @@ No valid authentication credentials supplied.
 
 ##### 404 Not Found
 Note not found.
+</details>
+
+
+### Get settings (`GET /settings`)
+<details><summary>Details</summary>
+
+*(since API v1.2)*
+
+#### Request parameters
+None.
+
+#### Response
+##### 200 OK
+- **Body**: user's app settings (see section [Settings](#settings)), example:
+```js
+{
+    "notesPath": "Notes",
+    "fileSuffix": ".txt"
+}
+```
+
+##### 400 Bad Request
+Endpoint not supported by installed notes app version (requires API version 1.2).
+
+##### 401 Unauthorized
+No valid authentication credentials supplied.
+</details>
+
+
+### Change settings (`PUT /settings`)
+<details><summary>Details</summary>
+
+*(since API v1.2)*
+
+#### Request parameters
+- **Body**: some or all settings attributes (see section [Settings](#settings)).
+Omitted settings attributes are not changed.
+Empty values are replaced by the settings attribute's default value.
+All values are sanitized (e.g. prevent path traversal attacks, check allowed suffixes), so the result can differ from the request (the request will still succeed).
+The client may show an information to the user if the response differs from the request.
+Example:
+```js
+{
+    "fileSuffix": ".md"
+}
+```
+
+#### Response
+##### 200 OK
+- **Body**: user's app settings after validation (see section [Settings](#settings)), example see section [Get settings](#get-settings-get-settings).
+
+##### 400 Bad Request
+Endpoint not supported by installed notes app version (requires API version 1.2).
+
+##### 401 Unauthorized
+No valid authentication credentials supplied.
 </details>

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -6,6 +6,7 @@ namespace OCA\Notes\Controller;
 
 use OCA\Notes\Service\NotesService;
 use OCA\Notes\Service\MetaService;
+use OCA\Notes\Service\SettingsService;
 
 use OCP\AppFramework\ApiController;
 use OCP\AppFramework\Http;
@@ -18,6 +19,8 @@ class NotesApiController extends ApiController {
 	private $service;
 	/** @var MetaService */
 	private $metaService;
+	/** @var SettingsService */
+	private $settingsService;
 	/** @var Helper */
 	private $helper;
 
@@ -26,11 +29,13 @@ class NotesApiController extends ApiController {
 		IRequest $request,
 		NotesService $service,
 		MetaService $metaService,
+		SettingsService $settingsService,
 		Helper $helper
 	) {
 		parent::__construct($AppName, $request);
 		$this->service = $service;
 		$this->metaService = $metaService;
+		$this->settingsService = $settingsService;
 		$this->helper = $helper;
 	}
 
@@ -207,6 +212,28 @@ class NotesApiController extends ApiController {
 		});
 	}
 
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+	 */
+	public function setSettings() {
+		return $this->helper->handleErrorResponse(function () {
+			$this->settingsService->set($this->helper->getUID(), $this->request->getParams());
+			return $this->getSettings();
+		});
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @CORS
+	 * @NoCSRFRequired
+	 */
+	public function getSettings() {
+		return $this->helper->handleErrorResponse(function () {
+			return $this->settingsService->getAll($this->helper->getUID());
+		});
+	}
 	/**
 	 * @NoAdminRequired
 	 * @NoCSRFRequired

--- a/src/App.vue
+++ b/src/App.vue
@@ -156,6 +156,7 @@ export default {
 				this.$router.push('/')
 			}
 			store.commit('removeAllNotes')
+			store.commit('clearSyncCache')
 			this.loading.notes = true
 			this.loadNotes()
 		},

--- a/src/store/sync.js
+++ b/src/store/sync.js
@@ -22,6 +22,11 @@ const mutations = {
 		}
 	},
 
+	clearSyncCache(state) {
+		state.etag = null
+		state.lastModified = 0
+	},
+
 	setSyncActive(state, active) {
 		state.active = active
 	},

--- a/tests/api/AbstractAPITest.php
+++ b/tests/api/AbstractAPITest.php
@@ -200,4 +200,41 @@ abstract class AbstractAPITest extends TestCase {
 		}
 		$this->checkReferenceNote($note, $responseNote, 'Updated note');
 	}
+
+	protected function checkObject(
+		\stdClass $ref,
+		\stdClass $obj,
+		string $messagePrefix
+	) : void {
+		foreach (get_object_vars($ref) as $key => $val) {
+			$this->assertObjectHasAttribute(
+				$key,
+				$obj,
+				$messagePrefix.': Object has property '.$key
+			);
+			$this->assertEquals(
+				$ref->$key,
+				$obj->$key,
+				$messagePrefix.': Property '.$key
+			);
+		}
+	}
+
+	protected function updateSettings(
+		\stdClass &$settings,
+		\stdClass $request,
+		\stdClass $expected,
+		string $messagePrefix
+	) {
+		$response = $this->http->request('PUT', 'settings', [ 'json' => $request ]);
+		$this->checkResponse($response, $messagePrefix, 200);
+		$responseSettings = json_decode($response->getBody()->getContents());
+		foreach (get_object_vars($request) as $key => $val) {
+			$settings->$key = $val;
+		}
+		foreach (get_object_vars($expected) as $key => $val) {
+			$settings->$key = $val;
+		}
+		$this->checkObject($settings, $responseSettings, $messagePrefix);
+	}
 }

--- a/tests/api/CommonAPITest.php
+++ b/tests/api/CommonAPITest.php
@@ -14,6 +14,11 @@ abstract class CommonAPITest extends AbstractAPITest {
 		'favorite' => 'boolean',
 	];
 
+	private $requiredSettings = [
+		'notesPath' => 'string',
+		'fileSuffix' => 'string',
+	];
+
 	private $autotitle;
 
 	public function __construct(string $apiVersion, bool $autotitle) {
@@ -243,5 +248,57 @@ abstract class CommonAPITest extends AbstractAPITest {
 		$auth = ['test', 'wrongpassword'];
 		$response = $this->http->request('GET', 'notes', [ 'auth' => $auth ]);
 		$this->checkResponse($response, 'Get existing notes', 401);
+	}
+
+	public function testGetSettings() : \stdClass {
+		if ($this->getAPIMajorVersion() < 1) {
+			$this->markTestSkipped('Settings API requires API v1');
+		}
+		$response = $this->http->request('GET', 'settings');
+		$this->checkResponse($response, 'Get settings', 200);
+		$settings = json_decode($response->getBody()->getContents());
+		foreach ($this->requiredSettings as $key => $type) {
+			$this->assertObjectHasAttribute($key, $settings, 'Settings has property '.$key);
+			$this->assertEquals($type, gettype($settings->$key), 'Property type of '.$key);
+		}
+		return $settings;
+	}
+
+	/**
+	 * @depends testCheckForReferenceNotes
+	 * @depends testGetSettings
+	 */
+	public function testSettings(array $refNotes, \stdClass $settings) : void {
+		if ($this->getAPIMajorVersion() < 1) {
+			$this->markTestSkipped('Settings API requires API v1');
+		}
+		$this->checkGetReferenceNotes($refNotes, 'Pre-condition');
+		$originalPath = $settings->notesPath;
+		$this->updateSettings($settings, (object)[
+			'notesPath' => 'New-Test-Notes-Folder1',
+			'fileSuffix' => '.md',
+		], (object)[], 'Update both settings');
+		$this->checkGetReferenceNotes([], 'Notes are gone after changing notes path');
+		$this->updateSettings($settings, (object)[
+			'notesPath' => '../../Test/./../New-Test-Notes-Folder2',
+		], (object)[
+			'notesPath' => 'New-Test-Notes-Folder2',
+		], 'Update notesPath with path traversal check');
+		$this->updateSettings($settings, (object)[
+			'fileSuffix' => 'illegal value',
+		], (object)[
+			'fileSuffix' => '.txt',
+		], 'Update fileSuffix with illegal value');
+		$this->updateSettings($settings, (object)[
+			'notesPath' => null,
+			'fileSuffix' => null,
+		], (object)[
+			'notesPath' => 'Notes',
+			'fileSuffix' => '.txt',
+		], 'Update settings with default values');
+		$this->updateSettings($settings, (object)[
+			'notesPath' => $originalPath,
+		], (object)[], 'Update notesPath to original value');
+		$this->checkGetReferenceNotes($refNotes, 'Post-condition');
 	}
 }


### PR DESCRIPTION
Provides access to the app settings through the API. This was requested in https://github.com/stefan-niedermann/nextcloud-notes/issues/916#issuecomment-711148998. However, my implementation differs to the proposed API. Please check, if this is fine for you, too @stefan-niedermann . My approach was easier :grin: 
Please note, that the API does not provide the list of allowed file suffixes. This is static for now. We could add a dynamic list later. Is this fine?

- [x] new API endpoints for getting and setting app settings
- [x] documentation for API changes
- [x] Test cases