### PR TITLE
slow-down refresh interval if app is hidden

### DIFF
--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -174,6 +174,7 @@ export default {
 		document.addEventListener('mozfullscreenchange', this.onDetectFullscreen)
 		document.addEventListener('fullscreenchange', this.onDetectFullscreen)
 		document.addEventListener('keydown', this.onKeyPress)
+		document.addEventListener('visibilitychange', this.onVisibilityChange)
 	},
 
 	destroyed() {
@@ -182,6 +183,7 @@ export default {
 		document.removeEventListener('mozfullscreenchange', this.onDetectFullscreen)
 		document.removeEventListener('fullscreenchange', this.onDetectFullscreen)
 		document.removeEventListener('keydown', this.onKeyPress)
+		document.removeEventListener('visibilitychange', this.onVisibilityChange)
 		store.commit('setSidebarOpen', false)
 		this.onUpdateTitle(null)
 	},
@@ -268,6 +270,13 @@ export default {
 			this.actionsOpen = false
 		},
 
+		onVisibilityChange() {
+			if (document.visibilityState === 'visible') {
+				this.stopRefreshTimer()
+				this.refreshNote()
+			}
+		},
+
 		stopRefreshTimer() {
 			if (this.refreshTimer !== null) {
 				clearTimeout(this.refreshTimer)
@@ -277,10 +286,11 @@ export default {
 
 		startRefreshTimer() {
 			this.stopRefreshTimer()
+			const interval = document.visibilityState === 'visible' ? config.interval.note.refresh : config.interval.note.refreshHidden
 			this.refreshTimer = setTimeout(() => {
 				this.refreshTimer = null
 				this.refreshNote()
-			}, config.interval.note.refresh * 1000)
+			}, interval * 1000)
 		},
 
 		refreshNote() {

--- a/src/config.js
+++ b/src/config.js
@@ -4,9 +4,11 @@ export const config = {
 			autosave: 1,
 			autotitle: 2,
 			refresh: 10,
+			refreshHidden: 120,
 		},
 		notes: {
 			refresh: 25,
+			refreshAfterHidden: 2,
 		},
 	},
 }


### PR DESCRIPTION
If the current browser-tab is hidden
- refreshing the list of notes (app navigation) is stopped
- refreshing the current note is set to every 2 minutes

When re-activating the browser-tab, then
- directly refresh the current note
- refresh the list of notes after 2 seconds