### PR TITLE
New attribute "readonly" for read-only notes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
         mkdir -p server/data/quotatest/files/
         cp -r notes/tests/reference-notes server/data/test/files/Notes
         cp -r notes/tests/reference-notes server/data/quotatest/files/Notes
+        chmod 444 server/data/test/files/Notes/ReadOnly/ReadOnly-Note.txt
         php server/occ files:scan --all
     - name: Start Nextcloud server
       working-directory: ../server/

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -21,6 +21,7 @@ The app and the API is mainly about notes. So, let's have a look about the attri
 |:----------|:-----|:-------------------------|:-------------------|
 | `id` | integer (read‑only) | Every note has a unique identifier which is created by the server. It can be used to query and update a specific note. | 1.0 |
 | `etag` | string (read‑only) | The note's entity tag (ETag) indicates if a note's attribute has changed. I.e., if the note changes, the ETag changes, too. Clients can use the ETag for detecting if the local note has to be updated from server and for optimistic concurrency control (see section [Preventing lost updates and conflict solution](#preventing-lost-updates-and-conflict-solution)). | 1.2 |
+| `readonly` | boolean (read‑only) | Indicates if the note is read-only. This is `true`, e.g., if a file or folder was shared by another user without allowing editing. If this attribute is `true`, then all read/write attributes become read-only; except for the `favorite` attribute. | 1.2 |
 | `content` | string (read/write) | Notes can contain arbitrary text. Formatting should be done using Markdown, but not every markup can be supported by every client. Therefore, markup should be used with care. | 1.0 |
 | `title` | string (read/write) | The note's title is also used as filename for the note's file. Therefore, some special characters are automatically removed and a sequential number is added if a note with the same title in the same category exists. When saving a title, the sanitized value is returned and should be adopted by your client. | 1.0 |
 | `category` | string (read/write) | Every note is assigned to a category. By default, the category is an empty string (not null), which means the note is uncategorized. Categories are mapped to folders in the file backend. Illegal characters are automatically removed and the respective folder is automatically created. Sub-categories (mapped to sub-folders) can be created by using `/` as delimiter. | 1.0 |
@@ -70,6 +71,7 @@ All defined routes in the specification are appended to this url. To access all 
     {
         "id": 76,
         "etag": "be284e00488c61c101ee28309d235e0b",
+        "readonly": false,
         "modified": 1376753464,
         "title": "New note",
         "category": "sub-directory",
@@ -101,6 +103,7 @@ No valid authentication credentials supplied.
 {
     "id": 76,
     "etag": "be284e00488c61c101ee28309d235e0b",
+    "readonly": false,
     "modified": 1376753464,
     "title": "New note",
     "category": "sub-directory",
@@ -167,13 +170,15 @@ Invalid ID supplied.
 ##### 401 Unauthorized
 No valid authentication credentials supplied.
 
+##### 403 Forbidden
+The note is read-only.
+
 ##### 404 Not Found
 Note not found.
 
 ##### 412 Precondition Failed
 *(since API v1.2)*
 Update cannot be performed since the note has been changed on the server in the meanwhile (concurrent change). The body contains the current note's state from server (see section [Note attributes](#note-attributes)), example see section [Get single note](#get-single-note-get-notesid). The client should use this response data in order to perform a conflict solution (see section [Preventing lost updates and conflict solution](#preventing-lost-updates-and-conflict-solution)).
-
 
 ##### 507 Insufficient Storage
 Not enough free storage for saving the note's content.
@@ -197,6 +202,9 @@ Invalid ID supplied.
 
 ##### 401 Unauthorized
 No valid authentication credentials supplied.
+
+##### 403 Forbidden
+The note is read-only.
 
 ##### 404 Not Found
 Note not found.

--- a/lib/Controller/Helper.php
+++ b/lib/Controller/Helper.php
@@ -119,6 +119,9 @@ class Helper {
 		} catch (\OCA\Notes\Service\InsufficientStorageException $e) {
 			$this->logException($e);
 			$response = $this->createErrorResponse($e, Http::STATUS_INSUFFICIENT_STORAGE);
+		} catch (\OCA\Notes\Service\NoteNotWritableException $e) {
+			$this->logException($e);
+			$response = $this->createErrorResponse($e, Http::STATUS_FORBIDDEN);
 		} catch (\OCP\Lock\LockedException $e) {
 			$this->logException($e);
 			$response = $this->createErrorResponse($e, Http::STATUS_LOCKED);

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -147,18 +147,18 @@ class NotesApiController extends ApiController {
 			$favorite
 		) {
 			$note = $this->helper->getNoteWithETagCheck($id, $this->request);
-			if ($content !== null) {
+			if ($content !== null && $content !== $note->getContent()) {
 				$note->setContent($content);
 			}
-			if ($modified !== null) {
+			if ($modified !== null && $modified !== $note->getModified()) {
 				$note->setModified($modified);
 			}
-			if ($title !== null) {
+			if ($title !== null && $title !== $note->getTitle()) {
 				$note->setTitleCategory($title, $category);
-			} elseif ($category !== null) {
+			} elseif ($category !== null && $category !== $note->getCategory()) {
 				$note->setCategory($category);
 			}
-			if ($favorite !== null) {
+			if ($favorite !== null && $favorite !== $note->getFavorite()) {
 				$note->setFavorite($favorite);
 			}
 			return $this->helper->getNoteData($note);

--- a/lib/Service/MetaService.php
+++ b/lib/Service/MetaService.php
@@ -179,6 +179,7 @@ class MetaService {
 			$note->getModified(),
 			$note->getCategory(),
 			$note->getFavorite(),
+			$note->getReadOnly(),
 			$meta->getContentEtag(),
 		];
 		return md5(json_encode($data));

--- a/lib/Service/Note.php
+++ b/lib/Service/Note.php
@@ -82,6 +82,10 @@ class Note {
 		return $this->noteUtil->getTagService()->isFavorite($this->getId());
 	}
 
+	public function getReadOnly() : bool {
+		return !$this->file->isUpdateable();
+	}
+
 
 	public function getData(array $exclude = []) : array {
 		$data = [];
@@ -99,6 +103,9 @@ class Note {
 		}
 		if (!in_array('favorite', $exclude)) {
 			$data['favorite'] = $this->getFavorite();
+		}
+		if (!in_array('readonly', $exclude)) {
+			$data['readonly'] = $this->getReadOnly();
 		}
 		$data['error'] = false;
 		$data['errorMessage'] = '';
@@ -125,10 +132,12 @@ class Note {
 
 
 	public function setTitle(string $title) : void {
+		$this->noteUtil->ensureNoteIsWritable($this->file);
 		$this->setTitleCategory($title);
 	}
 
 	public function setCategory(string $category) : void {
+		$this->noteUtil->ensureNoteIsWritable($this->file);
 		$this->setTitleCategory($this->getTitle(), $category);
 	}
 
@@ -136,6 +145,7 @@ class Note {
 	 * @throws \OCP\Files\NotPermittedException
 	 */
 	public function setTitleCategory(string $title, ?string $category = null) : void {
+		$this->noteUtil->ensureNoteIsWritable($this->file);
 		if ($category === null) {
 			$category = $this->getCategory();
 		}
@@ -155,11 +165,13 @@ class Note {
 	}
 
 	public function setContent(string $content) : void {
+		$this->noteUtil->ensureNoteIsWritable($this->file);
 		$this->noteUtil->ensureSufficientStorage($this->file->getParent(), strlen($content));
 		$this->file->putContent($content);
 	}
 
 	public function setModified(int $modified) : void {
+		$this->noteUtil->ensureNoteIsWritable($this->file);
 		$this->file->touch($modified);
 	}
 

--- a/lib/Service/NoteNotWritableException.php
+++ b/lib/Service/NoteNotWritableException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\Notes\Service;
+
+use Exception;
+
+class NoteNotWritableException extends Exception {
+}

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -6,6 +6,7 @@ namespace OCA\Notes\Service;
 
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\IDBConnection;
 
 class NoteUtil {
@@ -190,6 +191,17 @@ class NoteUtil {
 				'required are '.$requiredBytes
 			);
 			throw new InsufficientStorageException($requiredBytes.' are required in '.$folder->getPath());
+		}
+	}
+
+	/**
+	 * Checks if the file/folder is writable. Throws an Exception if not.
+	 * @param Node $node to be checked
+	 * @throws NoteNotWritableException
+	 */
+	public function ensureNoteIsWritable(Node $node) : void {
+		if (!$node->isUpdateable()) {
+			throw new NoteNotWritableException();
 		}
 	}
 }

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -118,6 +118,7 @@ class NotesService {
 	public function delete(string $userId, int $id) {
 		$notesFolder = $this->getNotesFolder($userId);
 		$file = $this->getFileById($notesFolder, $id);
+		$this->noteUtil->ensureNoteIsWritable($file);
 		$parent = $file->getParent();
 		$file->delete();
 		$this->noteUtil->deleteEmptyFolder($parent, $notesFolder);

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -15,6 +15,10 @@ export default {
 			type: String,
 			required: true,
 		},
+		readonly: {
+			type: Boolean,
+			required: true,
+		},
 	},
 
 	data() {
@@ -75,6 +79,10 @@ export default {
 				codeElement.addEventListener('mousedown', this.onClickCodeElement)
 				codeElement.addEventListener('touchstart', this.onClickCodeElement)
 			})
+
+			if (this.readonly) {
+				this.mde.codemirror.options.readOnly = true
+			}
 		},
 
 		onClickCodeElement(event) {

--- a/src/components/NavigationNoteItem.vue
+++ b/src/components/NavigationNoteItem.vue
@@ -6,7 +6,7 @@
 		:to="{ name: 'note', params: { noteId: note.id.toString() } }"
 		:class="{ actionsOpen }"
 		:loading="loading.note"
-		:editable="true"
+		:editable="!note.readonly"
 		:edit-label="t('notes', 'Rename')"
 		:edit-placeholder="t('notes', 'Note\'s title')"
 		@update:title="onRename"
@@ -15,7 +15,7 @@
 			<ActionButton :icon="actionFavoriteIcon" @click="onToggleFavorite">
 				{{ actionFavoriteText }}
 			</ActionButton>
-			<ActionButton :icon="actionDeleteIcon" @click="onDeleteNote">
+			<ActionButton v-if="!note.readonly" :icon="actionDeleteIcon" @click="onDeleteNote">
 				{{ t('notes', 'Delete note') }}
 			</ActionButton>
 			<ActionSeparator />

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -31,7 +31,11 @@
 					{{ preview ? t('notes', 'Empty note') : t('notes', 'Write …') }}
 				</div>
 				<ThePreview v-if="preview" :value="note.content" />
-				<TheEditor v-else :value="note.content" @input="onEdit" />
+				<TheEditor v-else
+					:value="note.content"
+					:readonly="note.readonly"
+					@input="onEdit"
+				/>
 			</div>
 			<span class="action-buttons">
 				<Actions :open.sync="actionsOpen" container=".action-buttons" menu-align="right">
@@ -54,6 +58,12 @@
 						@click="onToggleDistractionFree"
 					>
 						{{ fullscreen ? t('notes', 'Exit full screen') : t('notes', 'Full screen') }}
+					</ActionButton>
+				</Actions>
+				<Actions v-if="note.readonly">
+					<ActionButton>
+						<PencilOffIcon slot="icon" :size="18" fill-color="var(--color-main-text)" />
+						{{ t('notes', 'Note is read-only. You cannot change it.') }}
 					</ActionButton>
 				</Actions>
 				<Actions v-if="note.saveError" class="action-error">
@@ -86,6 +96,7 @@ import { showError } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 
 import SyncAlertIcon from 'vue-material-design-icons/SyncAlert'
+import PencilOffIcon from 'vue-material-design-icons/PencilOff'
 
 import { config } from '../config'
 import { fetchNote, refreshNote, saveNote, saveNoteManually, autotitleNote, conflictSolutionLocal, conflictSolutionRemote } from '../NotesService'
@@ -104,6 +115,7 @@ export default {
 		AppContent,
 		ConflictSolution,
 		Modal,
+		PencilOffIcon,
 		SyncAlertIcon,
 		TheEditor,
 		ThePreview,

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -8,7 +8,7 @@
 		@close="onCloseSidebar"
 	>
 		<div class="sidebar-content-wrapper">
-			<div class="note-category" :title="t('notes', 'Set category')">
+			<div v-if="!note.readonly" class="note-category" :title="t('notes', 'Set category')">
 				<h4>{{ t('notes', 'Category') }} <span v-tooltip="categoriesInfo" class="icon-info svg" /></h4>
 				<form class="category" @submit.prevent.stop="">
 					<Multiselect id="category"

--- a/tests/api/APIv1Test.php
+++ b/tests/api/APIv1Test.php
@@ -8,4 +8,34 @@ class APIv1Test extends CommonAPITest {
 	public function __construct() {
 		parent::__construct('1.2', false);
 	}
+
+	/** @depends testCheckForReferenceNotes */
+	public function testReadOnlyNote(array $refNotes) : void {
+		$readOnlyNotes = array_values(array_filter($refNotes, function ($note) {
+			return $note->readonly;
+		}));
+		$this->assertNotEmpty($readOnlyNotes, 'List of read only notes');
+		$note = clone $readOnlyNotes[0];
+		unset($note->etag);
+		$favorite = $note->favorite;
+		// request with all attributes (unchanged) and just change favorite should succeed
+		$upd = clone $note;
+		$upd->favorite = !$favorite;
+		$this->updateNote($note, $upd, (object)[]);
+		// changing other attributes should fail
+		$this->updateNote($note, (object)[ 'content' => 'New content' ], (object)[], null, 403);
+		$this->updateNote($note, (object)[ 'title' => 'New title' ], (object)[], null, 403);
+		$this->updateNote($note, (object)[ 'category' => 'New category' ], (object)[], null, 403);
+		$this->updateNote($note, (object)[ 'modified' => 700 ], (object)[], null, 403);
+		// change favorite back to origin
+		$this->updateNote($note, (object)[
+			'favorite' => $favorite,
+		], (object)[
+		]);
+		// delete should fail
+		$response = $this->http->request('DELETE', 'notes/'.$note->id);
+		$this->checkResponse($response, 'Delete read-only note note', 403);
+		// test if nothing has changed
+		$this->checkGetReferenceNotes($refNotes, 'After read-only tests');
+	}
 }

--- a/tests/api/AbstractAPITest.php
+++ b/tests/api/AbstractAPITest.php
@@ -201,6 +201,9 @@ abstract class AbstractAPITest extends TestCase {
 		}
 		$response = $this->http->request('PUT', 'notes/'.$note->id, $requestOptions);
 		$this->checkResponse($response, 'Update note '.$note->title, $statusExp);
+		if ($statusExp === 403) {
+			return $note;
+		}
 		$responseNote = json_decode($response->getBody()->getContents());
 		foreach (get_object_vars($request) as $key => $val) {
 			$note->$key = $val;

--- a/tests/api/CommonAPITest.php
+++ b/tests/api/CommonAPITest.php
@@ -7,6 +7,7 @@ namespace OCA\Notes\Tests\API;
 abstract class CommonAPITest extends AbstractAPITest {
 	private $requiredAttributes = [
 		'id' => 'integer',
+		'readonly' => 'boolean',
 		'content' => 'string',
 		'title' => 'string',
 		'category' => 'string',
@@ -122,6 +123,7 @@ abstract class CommonAPITest extends AbstractAPITest {
 		], (object)[
 			'title' => $this->autotitle ? 'First test note' : 'First manual title',
 			'category' => 'Test/New Category',
+			'readonly' => false,
 		]);
 		$testNotes[] = $this->createNote((object)[
 			'content' => 'Note with Defaults'.PHP_EOL.'This is some body content with some data.',
@@ -130,6 +132,7 @@ abstract class CommonAPITest extends AbstractAPITest {
 			'favorite' => false,
 			'category' => '',
 			'modified' => time(),
+			'readonly' => false,
 		]);
 		$this->checkGetReferenceNotes(array_merge($refNotes, $testNotes), 'After creating notes');
 		return $testNotes;

--- a/tests/reference-notes/ReadOnly/ReadOnly-Note.txt
+++ b/tests/reference-notes/ReadOnly/ReadOnly-Note.txt
@@ -1,0 +1,1 @@
+This is a read-only note.


### PR DESCRIPTION
- Checks if a note is writable
- sets the new attribute "readonly"
- API: announce this attribute over the API
- API: send 403 if a note can't be changed due to a read-only note
- web GUI: hides some buttons for read-only notes
- web GUI: disables editing for read-only notes

Closes #564