### PR TITLE
add setting for view mode

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -27,16 +27,7 @@ class SettingsService {
 		$this->l10n = $l10n;
 		$this->root = $root;
 		$this->attrs = [
-			'fileSuffix' => [
-				'default' => '.txt',
-				'validate' => function ($value) {
-					if (in_array($value, [ '.txt', '.md' ])) {
-						return $value;
-					} else {
-						return '.txt';
-					}
-				},
-			],
+			'fileSuffix' => $this->getListAttrs('.txt', '.md'),
 			'notesPath' => [
 				'default' => function (string $uid) {
 					return $this->getDefaultNotesPath($uid);
@@ -55,6 +46,21 @@ class SettingsService {
 					return implode(DIRECTORY_SEPARATOR, $path);
 				},
 			],
+			'noteMode' => $this->getListAttrs('edit', 'preview'),
+		];
+	}
+
+	private function getListAttrs(...$values) : array {
+		$first = $values[0];
+		return [
+			'default' => $first,
+			'validate' => function ($value) use ($values, $first) {
+				if (in_array($value, $values)) {
+					return $value;
+				} else {
+					return $first;
+				}
+			},
 		];
 	}
 

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -24,6 +24,16 @@
 				</option>
 			</select>
 		</div>
+		<div class="settings-block">
+			<p class="settings-hint">
+				<label for="noteMode">{{ t('notes', 'Display mode for notes') }}</label>
+			</p>
+			<select id="noteMode" v-model="settings.noteMode" @change="onChangeSettings">
+				<option v-for="mode in noteModes" :key="mode.value" :value="mode.value">
+					{{ mode.label }}
+				</option>
+			</select>
+		</div>
 	</AppNavigationSettings>
 </template>
 
@@ -45,6 +55,10 @@ export default {
 	data() {
 		return {
 			extensions: ['.txt', '.md'],
+			noteModes: [
+				{ value: 'edit', label: t('notes', 'Open in edit mode') },
+				{ value: 'preview', label: t('notes', 'Open in preview mode') },
+			],
 			saving: false,
 		}
 	},

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -212,7 +212,7 @@ export default {
 
 			this.onUpdateTitle(this.title)
 			this.loading = true
-			this.preview = false
+			this.preview = store.state.app.settings.noteMode === 'preview'
 			fetchNote(parseInt(this.noteId))
 				.then((note) => {
 					if (note.error) {


### PR DESCRIPTION
Adds a new setting "Display mode for notes" with options "Open in edit mode" and "Open in preview mode". If you open a note, it will be shown either in edit mode or in preview mode - depending on this setting. In both cases, you can still change the mode by using the action "Preview" resp. "Edit" in the three-dots-menu in the upper-right corner.

![Screenshot](https://user-images.githubusercontent.com/6277619/128592576-d556d67c-ff4b-463d-a848-665fff2befec.png)

Fixes #352.