### PR TITLE
Error handling and more

### DIFF
--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -88,7 +88,7 @@ export const fetchNotes = () => {
 			return response.data
 		})
 		.catch(err => {
-			if (err.response && err.response.status === 304) {
+			if (err?.response?.status === 304) {
 				store.commit('setSyncLastModified', err.response.headers['last-modified'])
 				return null
 			} else {
@@ -111,7 +111,7 @@ export const fetchNote = noteId => {
 			return response.data
 		})
 		.catch(err => {
-			if (err.response.status === 404) {
+			if (err?.response?.status === 404) {
 				throw err
 			} else {
 				console.error(err)
@@ -149,7 +149,14 @@ export const refreshNote = (noteId, lastETag) => {
 			return null
 		})
 		.catch(err => {
-			if (err.response.status !== 304) {
+			if (err?.response?.status === 304 || note.deleting) {
+				// ignore error if note is deleting or not changed
+				return null
+			} else if (err?.code === 'ECONNABORTED') {
+				// ignore cancelled request
+				console.debug('Refresh Note request was cancelled.')
+				return null
+			} else {
 				console.error(err)
 				handleSyncError(t('notes', 'Refreshing note {id} has failed.', { id: noteId }), err)
 			}
@@ -216,7 +223,7 @@ function _updateNote(note) {
 			}
 		})
 		.catch(err => {
-			if (err.response && err.response.status === 412) {
+			if (err?.response?.status === 412) {
 				// ETag does not match, try to merge changes
 				note.saveError = false
 				store.commit('setNoteAttribute', { noteId: note.id, attribute: 'conflict', value: undefined })

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -8,7 +8,7 @@
 			<Modal v-if="note.conflict && showConflict" size="full" @close="showConflict=false">
 				<div class="conflict-modal">
 					<div class="conflict-header">
-						{{ t('notes', 'The note has been changed in another session. Please choose which content should be saved.') }}
+						{{ t('notes', 'The note has been changed in another session. Please choose which version should be saved.') }}
 					</div>
 					<div class="conflict-solutions">
 						<ConflictSolution

--- a/tests/api/CommonAPITest.php
+++ b/tests/api/CommonAPITest.php
@@ -266,7 +266,12 @@ abstract class CommonAPITest extends AbstractAPITest {
 		$this->assertEquals(507, $response2->getStatusCode());
 	}
 
-	public function testUnauthorized() {
+	public function testNotAuthenticated() {
+		$response = $this->http->request('GET', 'notes', [ 'auth' => null ]);
+		$this->checkResponse($response, 'Get existing notes', 401);
+	}
+
+	public function testWrongCredentials() {
 		$auth = ['test', 'wrongpassword'];
 		$response = $this->http->request('GET', 'notes', [ 'auth' => $auth ]);
 		$this->checkResponse($response, 'Get existing notes', 401);


### PR DESCRIPTION
- [x] add test for access without authentication
- [x] don't show error if note was deleted or user left (see https://github.com/nextcloud/notes/pull/742#issuecomment-891604087)
- [x] change wording for conflicts (fixes #746)