### PR TITLE
Add Imageproxy to resolve relative Imagepaths

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -83,18 +83,19 @@ return ['routes' => [
 		'requirements' => ['id' => '\d+'],
 	],
 
-	//////////  I M A G E S  //////////
+	//////////  A T T A C H M E N T S  //////////
 
 	[
-		'name' => 'notes#getImage',
-		'url' => '/notes/image/{id}/{path}',
+		'name' => 'notes#getAttachment',
+		'url' => '/notes/{noteid}/attachment',
 		'verb' => 'GET',
-		'requirements' => ['id' => '\d+', 'path' => '.+'],
+		'requirements' => ['noteid' => '\d+'],
 	],
 	[
-		'name' => 'notes#createImage',
-		'url' => '/notes/newimage/{id}',
+		'name' => 'notes#uploadFile',
+		'url' => '/notes/{noteid}/attachment',
 		'verb' => 'POST',
+		'requirements' => ['noteid' => '\d+'],
 	],
 
 	//////////  S E T T I N G S  //////////

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -83,6 +83,14 @@ return ['routes' => [
 		'requirements' => ['id' => '\d+'],
 	],
 
+	//////////  I M A G E S  //////////
+
+	[
+		'name' => 'notes#getImage',
+		'url' => '/notes/image/{id}/{path}',
+		'verb' => 'GET',
+		'requirements' => ['id' => '\d+', 'path' => '.+'],
+	],
 
 	//////////  S E T T I N G S  //////////
 	['name' => 'settings#set', 'url' => '/settings', 'verb' => 'PUT'],
@@ -182,5 +190,5 @@ return ['routes' => [
 			'apiVersion' => '(v0.2|v1)',
 			'path' => '.+',
 		],
-	],
+	]
 ]];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -91,6 +91,11 @@ return ['routes' => [
 		'verb' => 'GET',
 		'requirements' => ['id' => '\d+', 'path' => '.+'],
 	],
+	[
+		'name' => 'notes#createImage',
+		'url' => '/notes/newimage/{id}',
+		'verb' => 'POST',
+	],
 
 	//////////  S E T T I N G S  //////////
 	['name' => 'settings#set', 'url' => '/settings', 'verb' => 'PUT'],

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -196,5 +196,5 @@ return ['routes' => [
 			'apiVersion' => '(v0.2|v1)',
 			'path' => '.+',
 		],
-	]
+	],
 ]];

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -287,13 +287,16 @@ No valid authentication credentials supplied.
 
 #### Response
 ##### 200 OK
-- **Body**: File: Delivers a raw file, or a JSON with additional error-information
+- **Body**: File: Delivers a raw file
 
 ##### 400 Bad Request
 Endpoint not supported by installed notes app version (requires API version 1.3).
 
 ##### 401 Unauthorized
 No valid authentication credentials supplied.
+
+##### 500 Bad Request
+There was an internal server error
 </details>
 
 
@@ -331,6 +334,10 @@ Invalid ID supplied.
 
 ##### 401 Unauthorized
 No valid authentication credentials supplied.
+
+##### 500 Bad Request
+The file was not uploaded because there was an internal error.
+
 </details>
 
 ## Preventing lost updates and conflict solution

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -5,12 +5,11 @@ In this document, the Notes API major version 1 and all its minor versions are d
 
 ## Minor versions
 
-| API version | Introduced with app version | Remarkable Changes                                 |
-|:-----------:|:----------------------------|:---------------------------------------------------|
-|   **1.0**   | Notes 3.3 (May 2020)        | Separate title, no auto rename based on content    |
-|   **1.1**   | Notes 3.4 (May 2020)        | Filter "Get all notes" by category                 |
-|   **1.2**   | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
-|   **1.3**   | Notes X                     | Attachments                                        |
+| API version | Introduced with app version | Remarkable Changes |
+|:-----------:|:----------------------------|:-------------------|
+|  **1.0**    | Notes 3.3 (May 2020)        | Separate title, no auto rename based on content |
+|  **1.1**    | Notes 3.4 (May 2020)        | Filter "Get all notes" by category |
+|  **1.2**    | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
 
 
 
@@ -132,7 +131,7 @@ Note not found.
 <details><summary>Details</summary>
 
 #### Request parameters
-- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example:
+- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example: 
 ```js
 {
     "title": "New note",
@@ -273,78 +272,6 @@ No valid authentication credentials supplied.
 </details>
 
 
-### Attachments (`GET /notes/{noteid}/attachment?path={path}`)
-<details><summary>Details</summary>
-
-*(since API v1.3)*
-
-#### Request parameters
-| Parameter | Type              | Description                                                        |
-|:------|:------------------|:-------------------------------------------------------------------|
-| `noteid` | integer, required | ID of the note to query.                                           |
-| `{path}` | String, optional  | This is the path to the attachment to query. Example: `../frog.jpg` | 1.2 |
-
-
-#### Response
-##### 200 OK
-- **Body**: File: Delivers a raw file
-
-##### 400 Bad Request
-Endpoint not supported by installed notes app version (requires API version 1.3).
-
-##### 401 Unauthorized
-No valid authentication credentials supplied.
-
-##### 404 File not Found
-The requested file was not found in the specified path
-</details>
-
-
-
-### Create Attachments (`POST /notes/{noteid}/attachment`)
-<details><summary>Details</summary>
-
-*(since API v1.3)*
-
-#### Request parameters
-| Parameter | Type              | Description                                                        |
-|:------|:------------------|:-------------------------------------------------------------------|
-| `noteid` | integer, required | ID of the note to query.                                           |
-
-- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example:
-```js
-{
-    "file": "filedata from input type=\"file\""
-}
-// for an example, look at `src/components/EditorEasyMDE.vue Line 187`
-```
-
-#### Response
-##### 200 OK
-```js
-{
-    "filename": String,
-    "filepath": String,
-    "wasUploaded": Boolean
-}
-```
-
-##### 400 Bad Request
-Invalid ID supplied.
-
-##### 401 Unauthorized
-No valid authentication credentials supplied.
-
-##### 500 Bad Request
-The file was not uploaded because there was an internal error.
-```js
-{
-    "filename": String,
-    "filepath": String,
-    "wasUploaded": Boolean
-}
-```
-</details>
 
 ## Preventing lost updates and conflict solution
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -295,8 +295,8 @@ Endpoint not supported by installed notes app version (requires API version 1.3)
 ##### 401 Unauthorized
 No valid authentication credentials supplied.
 
-##### 500 Bad Request
-There was an internal server error
+##### 404 File not Found
+The requested file was not found in the specified path
 </details>
 
 

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -337,7 +337,13 @@ No valid authentication credentials supplied.
 
 ##### 500 Bad Request
 The file was not uploaded because there was an internal error.
-
+```js
+{
+    "filename": String,
+    "filepath": String,
+    "wasUploaded": Boolean
+}
+```
 </details>
 
 ## Preventing lost updates and conflict solution

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -5,11 +5,12 @@ In this document, the Notes API major version 1 and all its minor versions are d
 
 ## Minor versions
 
-| API version | Introduced with app version | Remarkable Changes |
-|:-----------:|:----------------------------|:-------------------|
-|  **1.0**    | Notes 3.3 (May 2020)        | Separate title, no auto rename based on content |
-|  **1.1**    | Notes 3.4 (May 2020)        | Filter "Get all notes" by category |
-|  **1.2**    | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
+| API version | Introduced with app version | Remarkable Changes                                 |
+|:-----------:|:----------------------------|:---------------------------------------------------|
+|   **1.0**   | Notes 3.3 (May 2020)        | Separate title, no auto rename based on content    |
+|   **1.1**   | Notes 3.4 (May 2020)        | Filter "Get all notes" by category                 |
+|   **1.2**   | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
+|   **1.3**   | Notes X                     | Attachments                                        |
 
 
 
@@ -131,7 +132,7 @@ Note not found.
 <details><summary>Details</summary>
 
 #### Request parameters
-- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example: 
+- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example:
 ```js
 {
     "title": "New note",
@@ -272,6 +273,65 @@ No valid authentication credentials supplied.
 </details>
 
 
+### Attachments (`GET /notes/{noteid}/attachment?path={path}`)
+<details><summary>Details</summary>
+
+*(since API v1.3)*
+
+#### Request parameters
+| Parameter | Type              | Description                                                        |
+|:------|:------------------|:-------------------------------------------------------------------|
+| `noteid` | integer, required | ID of the note to query.                                           |
+| `{path}` | String, optional  | This is the path to the attachment to query. Example: `../frog.jpg` | 1.2 |
+
+
+#### Response
+##### 200 OK
+- **Body**: File: Delivers a raw file, or a JSON with additional error-information
+
+##### 400 Bad Request
+Endpoint not supported by installed notes app version (requires API version 1.3).
+
+##### 401 Unauthorized
+No valid authentication credentials supplied.
+</details>
+
+
+
+### Create Attachments (`POST /notes/{noteid}/attachment`)
+<details><summary>Details</summary>
+
+*(since API v1.3)*
+
+#### Request parameters
+| Parameter | Type              | Description                                                        |
+|:------|:------------------|:-------------------------------------------------------------------|
+| `noteid` | integer, required | ID of the note to query.                                           |
+
+- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example:
+```js
+{
+    "file": "filedata from input type=\"file\""
+}
+// for an example, look at `src/components/EditorEasyMDE.vue Line 187`
+```
+
+#### Response
+##### 200 OK
+```js
+{
+    "filename": String,
+    "filepath": String,
+    "wasUploaded": Boolean
+}
+```
+
+##### 400 Bad Request
+Invalid ID supplied.
+
+##### 401 Unauthorized
+No valid authentication credentials supplied.
+</details>
 
 ## Preventing lost updates and conflict solution
 

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -341,10 +341,9 @@ class NotesController extends Controller {
 	}
 
 	/**
-	* @NoAdminRequired
-	*/
-	public function createImage($id): JSONResponse
-	{
+	 * @NoAdminRequired
+	 */
+	public function createImage($id): JSONResponse {
 		$file = $this->request->getUploadedFile('image');
 		$result = $this->notesService->createImage(
 			$this->helper->getUID(),
@@ -354,6 +353,4 @@ class NotesController extends Controller {
 
 		return new JSONResponse($result);
 	}
-
-
 }

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -342,10 +342,12 @@ class NotesController extends Controller {
 					return new DataResponse($notfoundMessage, Http::STATUS_NOT_FOUND);
 				}
 			} catch (Exception $ex) {
-				//this fails rather silently. The exception is not useful aswell. It only occurs when a file does not exist.
+				// this fails rather silently. The exception is not useful. It only occurs when a file does not exist.
 				return new DataResponse($notfoundMessage, Http::STATUS_NOT_FOUND);
 			}
-			return new FileDisplayResponse($targetimage, Http::STATUS_OK, ['Content-Type' => $targetimage->getMimetype(), 'Cache-Control' => 'public, max-age=604800']);
+			$headers = ['Content-Type' => $targetimage->getMimetype(), 'Cache-Control' => 'public, max-age=604800'];
+
+			return new FileDisplayResponse($targetimage, Http::STATUS_OK, $headers);
 		} catch (\Exception $e) {
 			return new DataResponse($notfoundMessage, Http::STATUS_NOT_FOUND);
 		}

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -333,10 +333,12 @@ class NotesController extends Controller {
 
 			foreach ($notenode->getDirectoryListing() as $file) {
 				if (str_ends_with($file->getPath(), $path)) {
-					return new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image/jpeg', 'Cache-Control' => 'public, max-age=604800']);
+					//make sure the file is in the notes folder
+					if (str_starts_with($file->getPath(), $notesFolderPath)) {
+						return new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => 'image/jpeg', 'Cache-Control' => 'public, max-age=604800']);
+					}
 				}
 			}
-
 		} catch (\Exception $e) {
 			return new JSONResponse($e->getMessage());
 		}

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -330,7 +330,7 @@ class NotesController extends Controller {
 			$targetimage = $this->root->get($relativeImageNode->getPath()."/".$path);
 			return new FileDisplayResponse($targetimage, Http::STATUS_OK, ['Content-Type' => 'image/jpeg', 'Cache-Control' => 'public, max-age=604800']);
 		} catch (\Exception $e) {
-			return new DataResponse([$e], Http::STATUS_INTERNAL_SERVER_ERROR);
+			return new DataResponse([$e], Http::STATUS_NOT_FOUND);
 		}
 	}
 

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -339,4 +339,21 @@ class NotesController extends Controller {
 			return new JSONResponse($e->getMessage());
 		}
 	}
+
+	/**
+	* @NoAdminRequired
+	*/
+	public function createImage($id): JSONResponse
+	{
+		$file = $this->request->getUploadedFile('image');
+		$result = $this->notesService->createImage(
+			$this->helper->getUID(),
+			intval($id),
+			$file
+		);
+
+		return new JSONResponse($result);
+	}
+
+
 }

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -319,8 +319,7 @@ class NotesController extends Controller {
 				$notePath .= $note->getCategory() . "/";
 			}
 
-
-			//because of how the internet works, ../ cannot work in the url and get's removed. We use ;;/ as a placeholder.
+			// calculate how many parentnodes we need to get 'up'
 			$parentcount = substr_count($path, '../');
 			$path = str_replace("../", "", $path);
 
@@ -341,14 +340,10 @@ class NotesController extends Controller {
 	 */
 	public function uploadFile($noteid): DataResponse {
 		$file = $this->request->getUploadedFile('file');
-		$result = $this->notesService->createImage(
+		return $this->notesService->createImage(
 			$this->helper->getUID(),
 			intval($noteid),
 			$file
 		);
-		if ($result['wasUploaded']) {
-			return new DataResponse([$result], Http::STATUS_OK);
-		}
-		return new DataResponse([$result], Http::STATUS_INTERNAL_SERVER_ERROR);
 	}
 }

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -322,16 +322,12 @@ class NotesController extends Controller {
 			$parentcount = substr_count($path, ';;/');
 			$path = str_replace(";;/", "", $path);
 
-			$imagepath = $notePath . $path;
-			$origin = $this->root->get($imagepath)->getParent();
-			$notenode = $origin;
+			$relativeImageNode = $this->root->get($notePath);
 			for ($i = 0; $i < $parentcount; $i++) {
-				$notenode = $notenode->getParent();
+				$relativeImageNode = $relativeImageNode->getParent();
 			}
 
-			//return new JSONResponse($notenode->getPath()."-".$origin->getPath()."-".$parentcount);
-
-			foreach ($notenode->getDirectoryListing() as $file) {
+			foreach ($relativeImageNode->getDirectoryListing() as $file) {
 				if (str_ends_with($file->getPath(), $path)) {
 					//make sure the file is in the notes folder
 					if (str_starts_with($file->getPath(), $notesFolderPath)) {

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -309,21 +309,13 @@ class NotesController extends Controller {
 	 * @NoCSRFRequired
 	 * @return JSONResponse|FileDisplayResponse
 	 */
-	public function getImage(int $id, string $path) {
+	public function getAttachment(int $noteid, string $path) {
 		try {
-			//decode
-			$path = base64_decode($path);
-			$note = $this->notesService->get($this->helper->getUID(), $id);
-
+			$note = $this->notesService->get($this->helper->getUID(), $noteid);
 			$notesFolderPath = $this->notesService->getNotesFolder($this->helper->getUID())->getPath();
 			$notePath = $notesFolderPath . "/";
 			if ($note->getCategory() != "") {
 				$notePath .= $note->getCategory() . "/";
-			}
-
-			//check if targetimage contains subdirectory
-			if(str_contains("/", $path)){
-
 			}
 
 
@@ -346,14 +338,13 @@ class NotesController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function createImage($id): JSONResponse {
-		$file = $this->request->getUploadedFile('image');
+	public function uploadFile($noteid): JSONResponse {
+		$file = $this->request->getUploadedFile('file');
 		$result = $this->notesService->createImage(
 			$this->helper->getUID(),
-			intval($id),
+			intval($noteid),
 			$file
 		);
-
 		return new JSONResponse($result);
 	}
 }

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -339,7 +339,7 @@ class NotesController extends Controller {
 	 * @NoAdminRequired
 	 * @return DataResponse
 	 */
-	public function uploadFile($noteid): JSONResponse {
+	public function uploadFile($noteid): DataResponse {
 		$file = $this->request->getUploadedFile('file');
 		$result = $this->notesService->createImage(
 			$this->helper->getUID(),
@@ -347,8 +347,8 @@ class NotesController extends Controller {
 			$file
 		);
 		if ($result['wasUploaded']) {
-			return new DataResponse([], Http::STATUS_OK);
+			return new DataResponse([$result], Http::STATUS_OK);
 		}
-		return new DataResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		return new DataResponse([$result], Http::STATUS_INTERNAL_SERVER_ERROR);
 	}
 }

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -9,6 +9,7 @@ use OCA\Notes\Service\MetaService;
 use OCA\Notes\Service\SettingsService;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
@@ -307,7 +308,7 @@ class NotesController extends Controller {
 	 * With help from: https://github.com/nextcloud/cookbook
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
-	 * @return JSONResponse|FileDisplayResponse
+	 * @return DataResponse|FileDisplayResponse
 	 */
 	public function getAttachment(int $noteid, string $path) {
 		try {
@@ -329,14 +330,14 @@ class NotesController extends Controller {
 			}
 			$targetimage = $this->root->get($relativeImageNode->getPath()."/".$path);
 			return new FileDisplayResponse($targetimage, Http::STATUS_OK, ['Content-Type' => 'image/jpeg', 'Cache-Control' => 'public, max-age=604800']);
-
 		} catch (\Exception $e) {
-			return new JSONResponse(["This image was not found.", $e->getMessage()]);
+			return new DataResponse([$e], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 	}
 
 	/**
 	 * @NoAdminRequired
+	 * @return DataResponse
 	 */
 	public function uploadFile($noteid): JSONResponse {
 		$file = $this->request->getUploadedFile('file');
@@ -345,6 +346,9 @@ class NotesController extends Controller {
 			intval($noteid),
 			$file
 		);
-		return new JSONResponse($result);
+		if ($result['wasUploaded']) {
+			return new DataResponse([], Http::STATUS_OK);
+		}
+		return new DataResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 	}
 }

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -221,8 +221,5 @@ class NotesService {
 		}
 
 		return $result;
-
 	}
-
-
 }

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -137,7 +137,7 @@ class NotesService {
 	 * @param string $userId the user id
 	 * @return Folder
 	 */
-	public function getNotesFolder(string $userId) : Folder {
+	private function getNotesFolder(string $userId) : Folder {
 		$userPath = $this->noteUtil->getRoot()->getUserFolder($userId)->getPath();
 		$path = $userPath . '/' . $this->settings->get($userId, 'notesPath');
 		$folder = $this->noteUtil->getOrCreateFolder($path);
@@ -228,6 +228,7 @@ class NotesService {
 	 * @param $userId
 	 * @param $noteid
 	 * @param $fileDataArray
+	 * @throws NotPermittedException
 	 * https://github.com/nextcloud/deck/blob/master/lib/Service/AttachmentService.php
 	 */
 	public function createImage(string $userId, int $noteid, $fileDataArray) {
@@ -253,14 +254,6 @@ class NotesService {
 		$result['filepath'] = $parent->getPath() . '/' . $filename;
 		$result['wasUploaded'] = true;
 
-		try {
-			$this->noteUtil->getRoot()->newFile($parent->getPath() . '/' . $filename, $content);
-		} catch (NotPermittedException $e) {
-			$result['wasUploaded'] = false;
-		}
-		if ($result['wasUploaded']) {
-			return $result;
-		}
-		return null;
+		$this->noteUtil->getRoot()->newFile($parent->getPath() . '/' . $filename, $content);
 	}
 }

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -191,9 +191,9 @@ class NotesService {
 	}
 
 	/**
-	 * @param $cardId
-	 * @param $type
-	 * @param $data
+	 * @param $uid
+	 * @param $noteid
+	 * @param $fileDataArray
 	 * @return DataResponse
 	 * https://github.com/nextcloud/deck/blob/master/lib/Service/AttachmentService.php
 	 */
@@ -215,6 +215,7 @@ class NotesService {
 		$content = fread($fp, $fileDataArray['size']);
 		fclose($fp);
 
+		$result = [];
 		$result['filename'] = $filename;
 		$result['filepath'] = $parent->getPath() . "/" . $filename;
 		$result['wasUploaded'] = true;

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -136,7 +136,7 @@ class NotesService {
 	 * @param string $userId the user id
 	 * @return Folder
 	 */
-	private function getNotesFolder(string $userId) : Folder {
+	public function getNotesFolder(string $userId) : Folder {
 		$userPath = $this->noteUtil->getRoot()->getUserFolder($userId)->getPath();
 		$path = $userPath . '/' . $this->settings->get($userId, 'notesPath');
 		$folder = $this->noteUtil->getOrCreateFolder($path);

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -1,11 +1,14 @@
 <template>
 	<div class="markdown-editor" @click="onClickEditor">
 		<textarea />
+		<input type="submit" id="123" @click="onClickUpload">
 	</div>
 </template>
 <script>
 
 import EasyMDE from 'easymde'
+import axios from "@nextcloud/axios";
+import {generateUrl} from "@nextcloud/router";
 
 export default {
 	name: 'EditorEasyMDE',
@@ -19,6 +22,10 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		noteid: {
+			type: String,
+			required: true,
+		}
 	},
 
 	data() {
@@ -58,6 +65,7 @@ export default {
 
 	methods: {
 		initialize() {
+
 			const config = Object.assign({
 				element: this.$el.firstElementChild,
 				initialValue: this.value,
@@ -119,6 +127,35 @@ export default {
 				this.mde.codemirror.setCursor(this.mde.codemirror.lineCount(), 0)
 				this.mde.codemirror.focus()
 			}
+		},
+
+		async onClickUpload() {
+
+			var doc = this.mde.codemirror.getDoc();
+			var cur = this.mde.codemirror.getCursor()
+
+			var id = this.noteid
+
+			var fileSelector = document.createElement('input');
+			fileSelector.setAttribute('type', 'file');
+
+			fileSelector.onchange = async function () {
+				const fd = new FormData();
+				fd.append('image', fileSelector.files[0]);
+				const response = await axios({
+					method: 'POST',
+					url: generateUrl('apps/notes') + '/notes/newimage/' + id,
+					data: fd,
+				})
+
+				var pos = {
+					line: cur.line
+				};
+
+				var name = response.data['filename'];
+				doc.replaceRange("!["+name+"]("+name+")", pos);
+			}
+			fileSelector.click();
 		},
 
 	},

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -1,7 +1,11 @@
 <template>
-	<div class="markdown-editor" @click="onClickEditor">
-		<textarea />
-		<input type="submit" id="123" @click="onClickUpload">
+	<div>
+		<div class="toolbar">
+			<input type="submit" id="123" @click="onClickUpload" :value="t('notes', 'Upload Image')">
+		</div>
+		<div class="markdown-editor" @click="onClickEditor">
+			<textarea />
+		</div>
 	</div>
 </template>
 <script>
@@ -67,7 +71,7 @@ export default {
 		initialize() {
 
 			const config = Object.assign({
-				element: this.$el.firstElementChild,
+				element: this.$el.lastElementChild.firstElementChild,
 				initialValue: this.value,
 				renderingConfig: {},
 			}, this.config)
@@ -288,5 +292,11 @@ export default {
 .CodeMirror .cm-formatting-task.cm-property + span {
 	opacity: 0.5;
 	text-decoration: line-through;
+}
+
+.toolbar {
+	border-bottom: darkgray 1px solid;
+	padding-left: 30px;
+	padding-bottom: 10px;
 }
 </style>

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -1,19 +1,5 @@
 <template>
 	<div>
-		<div class="toolbar">
-			<input
-				type="submit"
-				id="123"
-				@click="onClickUpload"
-				:value="t('notes', 'Upload Image')"
-			>
-			<input
-				type="submit"
-				id="456"
-				@click="onClickSelect"
-				:value="t('notes', 'Select Image')"
-			>
-		</div>
 		<div class="markdown-editor" @click="onClickEditor">
 			<textarea />
 		</div>
@@ -330,11 +316,5 @@ export default {
 .CodeMirror .cm-formatting-task.cm-property + span {
 	opacity: 0.5;
 	text-decoration: line-through;
-}
-
-.toolbar {
-	border-bottom: darkgray 1px solid;
-	padding-left: 30px;
-	padding-bottom: 10px;
 }
 </style>

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -184,10 +184,10 @@ export default {
 			temporaryInput.setAttribute('type', 'file')
 			temporaryInput.onchange = async function() {
 				const data = new FormData()
-				data.append('image', temporaryInput.files[0])
+				data.append('file', temporaryInput.files[0])
 				const response = await axios({
 					method: 'POST',
-					url: generateUrl('apps/notes') + '/notes/newimage/' + id,
+					url: generateUrl('apps/notes') + '/notes/' + id + "/attachment",
 					data,
 				})
 				const name = response.data.filename

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -132,31 +132,34 @@ export default {
 		},
 
 		async onClickSelect() {
-			const apppath = "/"+store.state.app.settings.notesPath
+			const apppath = '/' + store.state.app.settings.notesPath
 			const categories = store.getters.getCategories()
-			const currentNotePath = apppath+"/"+categories
+			const currentNotePath = apppath + '/' + categories
 
 			const doc = this.mde.codemirror.getDoc()
 			const cursor = this.mde.codemirror.getCursor()
 			OC.dialogs.filepicker(
-				t("notes", "Select an image"),
+				t('notes', 'Select an image'),
 				(path) => {
 
-					if(!path.startsWith(apppath)){
-						OC.dialogs.alert(t("notes", "You cannot select images outside of your notes folder. Your notes folder is: {folder}", {folder: apppath}), t("notes", "Wrong Image"),)
+					if (!path.startsWith(apppath)) {
+						OC.dialogs.alert(
+							t('notes', 'You cannot select images outside of your notes folder. Your notes folder is: {folder}', { folder: apppath }),
+							t('notes', 'Wrong Image'),
+						)
 						return
 					}
-					const noteLevel = ((currentNotePath+"/").split("/").length) -1
-					const imageLevel = (path.split("/").length - 1)
+					const noteLevel = ((currentNotePath + '/').split('/').length) - 1
+					const imageLevel = (path.split('/').length - 1)
 					const upwardsLevel = noteLevel - imageLevel
-					for (let i = 0; i < upwardsLevel; i++)  {
-						path = "../"+path
+					for (let i = 0; i < upwardsLevel; i++) {
+						path = '../' + path
 					}
-					path = path.replace(apppath+"/", "")
+					path = path.replace(apppath + '/', '')
 					doc.replaceRange('![' + path + '](' + path + ')', { line: cursor.line })
 				},
 				false,
-				["image/jpeg", "image/png"],
+				['image/jpeg', 'image/png'],
 				true,
 				OC.dialogs.FILEPICKER_TYPE_CHOOSE,
 				currentNotePath
@@ -175,7 +178,7 @@ export default {
 				data.append('file', temporaryInput.files[0])
 				const response = await axios({
 					method: 'POST',
-					url: generateUrl('apps/notes') + '/notes/' + id + "/attachment",
+					url: generateUrl('apps/notes') + '/notes/' + id + '/attachment',
 					data,
 				})
 				const name = response.data[0].filename

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -27,7 +27,7 @@ export default {
 		noteid: {
 			type: String,
 			required: true,
-		}
+		},
 	},
 
 	data() {
@@ -183,7 +183,7 @@ export default {
 				})
 				const name = response.data[0].filename
 				const position = {
-					line: cursor.line
+					line: cursor.line,
 				}
 				doc.replaceRange('![' + name + '](' + name + ')', position)
 			}

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -1,8 +1,6 @@
 <template>
-	<div>
-		<div class="markdown-editor" @click="onClickEditor">
-			<textarea />
-		</div>
+	<div class="markdown-editor" @click="onClickEditor">
+		<textarea />
 	</div>
 </template>
 <script>
@@ -67,9 +65,8 @@ export default {
 
 	methods: {
 		initialize() {
-
 			const config = Object.assign({
-				element: this.$el.lastElementChild.firstElementChild,
+				element: this.$el.firstElementChild,
 				initialValue: this.value,
 				renderingConfig: {},
 			}, this.config)

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -190,7 +190,7 @@ export default {
 					url: generateUrl('apps/notes') + '/notes/' + id + "/attachment",
 					data,
 				})
-				const name = response.data.filename
+				const name = response.data[0].filename
 				const position = {
 					line: cursor.line
 				}

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -1,7 +1,12 @@
 <template>
 	<div>
 		<div class="toolbar">
-			<input type="submit" id="123" @click="onClickUpload" :value="t('notes', 'Upload Image')">
+			<input
+				type="submit"
+				id="123"
+				@click="onClickUpload"
+				:value="t('notes', 'Upload Image')"
+			>
 		</div>
 		<div class="markdown-editor" @click="onClickEditor">
 			<textarea />
@@ -11,8 +16,8 @@
 <script>
 
 import EasyMDE from 'easymde'
-import axios from "@nextcloud/axios";
-import {generateUrl} from "@nextcloud/router";
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
 
 export default {
 	name: 'EditorEasyMDE',
@@ -134,34 +139,29 @@ export default {
 		},
 
 		async onClickUpload() {
+			const doc = this.mde.codemirror.getDoc()
+			const cursor = this.mde.codemirror.getCursor()
+			const id = this.noteid
 
-			var doc = this.mde.codemirror.getDoc();
-			var cur = this.mde.codemirror.getCursor()
-
-			var id = this.noteid
-
-			var fileSelector = document.createElement('input');
-			fileSelector.setAttribute('type', 'file');
-
-			fileSelector.onchange = async function () {
-				const fd = new FormData();
-				fd.append('image', fileSelector.files[0]);
+			const temporaryInput = document.createElement('input')
+			temporaryInput.setAttribute('type', 'file')
+			temporaryInput.onchange = async function() {
+				const data = new FormData()
+				data.append('image', temporaryInput.files[0])
 				const response = await axios({
 					method: 'POST',
 					url: generateUrl('apps/notes') + '/notes/newimage/' + id,
-					data: fd,
+					data,
 				})
+				const name = response.data.filename
+				const position = {
+					line: cursor.line
+				}
 
-				var pos = {
-					line: cur.line
-				};
-
-				var name = response.data['filename'];
-				doc.replaceRange("!["+name+"]("+name+")", pos);
+				doc.replaceRange('![' + name + '](' + name + ')', position)
 			}
-			fileSelector.click();
+			temporaryInput.click()
 		},
-
 	},
 }
 </script>

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -7,6 +7,12 @@
 				@click="onClickUpload"
 				:value="t('notes', 'Upload Image')"
 			>
+			<input
+				type="submit"
+				id="456"
+				@click="onClickSelect"
+				:value="t('notes', 'Select Image')"
+			>
 		</div>
 		<div class="markdown-editor" @click="onClickEditor">
 			<textarea />
@@ -136,6 +142,37 @@ export default {
 				this.mde.codemirror.setCursor(this.mde.codemirror.lineCount(), 0)
 				this.mde.codemirror.focus()
 			}
+		},
+
+		async onClickSelect() {
+			//todo: fix those hardcoded paths
+			const apppath = "/Notes"
+			const categories = "/"
+			const base = apppath+categories
+			const doc = this.mde.codemirror.getDoc()
+			const cursor = this.mde.codemirror.getCursor()
+			OC.dialogs.filepicker(
+				t("notes", "Select an image"),
+				(path) => {
+
+					if(!path.startsWith(apppath)){
+						OC.dialogs.alert(t("notes", "You cannot select images outside of your notes folder. Your notes folder is: {folder}",{folder: apppath}), t("notes", "Wrong Image"),)
+						return
+					}
+
+					path = path.replace(base, "")
+					const position = {
+						line: cursor.line
+					}
+
+					doc.replaceRange('![' + path + '](' + path + ')', position)
+				},
+				false,
+				["image/jpeg", "image/png"],
+				true,
+				OC.dialogs.FILEPICKER_TYPE_CHOOSE,
+				"/Notizen"
+			)
 		},
 
 		async onClickUpload() {

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -5,6 +5,7 @@
 <script>
 
 import MarkdownIt from 'markdown-it'
+import { generateUrl } from '@nextcloud/router'
 
 export default {
 	name: 'EditorMarkdownIt',
@@ -46,10 +47,9 @@ export default {
 			//rewrite dots to ; for url-encoding. See the corresponding API
 			source = source.replace("../", ";;/");
 
-			// properly determine main url
-
+			var id = "199"
 			if(!source.startsWith("http")) {
-				source = "http://localhost/index.php/apps/notes/notes/image/199/" + source;
+				source = generateUrl('apps/notes') + "/notes/image/" + id + "/" + source;
 			}
 
 			tokens[idx].attrs[aIndex][1] = source

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -15,6 +15,10 @@ export default {
 			type: String,
 			required: true,
 		},
+		noteid: {
+			type: String,
+			required: true,
+		}
 	},
 
 	data() {
@@ -32,32 +36,6 @@ export default {
 				linkify: true,
 			});
 
-
-		// https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
-		// Remember old renderer, if overridden, or proxy to default renderer
-		var defaultRender = markdown.renderer.rules.image || function(tokens, idx, options, env, self) {
-			return self.renderToken(tokens, idx, options);
-		};
-
-		markdown.renderer.rules.image = function (tokens, idx, options, env, self) {
-			// If you are sure other plugins can't add `target` - drop check below
-			var aIndex = tokens[idx].attrIndex('src');
-			var source = tokens[idx].attrs[aIndex][1];
-
-			//rewrite dots to ; for url-encoding. See the corresponding API
-			source = source.replace("../", ";;/");
-
-			var id = "199"
-			if(!source.startsWith("http")) {
-				source = generateUrl('apps/notes') + "/notes/image/" + id + "/" + source;
-			}
-
-			tokens[idx].attrs[aIndex][1] = source
-			// pass token to default renderer.
-			return defaultRender(tokens, idx, options, env, self);
-		};
-
-
 		return {
 			html: '',
 			md,
@@ -70,12 +48,38 @@ export default {
 	},
 
 	created() {
+		this.setImageRule(this.noteid)
 		this.onUpdate()
 	},
 
 	methods: {
 		onUpdate() {
 			this.html = this.md.render(this.value)
+		},
+		setImageRule(id) {
+			// https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
+			// Remember old renderer, if overridden, or proxy to default renderer
+			var defaultRender = this.md.renderer.rules.image || function(tokens, idx, options, env, self) {
+				return self.renderToken(tokens, idx, options);
+			};
+
+			this.md.renderer.rules.image = function (tokens, idx, options, env, self) {
+				// If you are sure other plugins can't add `target` - drop check below
+				var aIndex = tokens[idx].attrIndex('src');
+				var source = tokens[idx].attrs[aIndex][1];
+
+				//rewrite dots to ; for url-encoding. See the corresponding API
+				source = source.replaceAll("../", ";;/");
+
+				if(!source.startsWith("http")) {
+					source = generateUrl('apps/notes') + "/notes/image/" + id + "/" + source;
+				}
+
+				tokens[idx].attrs[aIndex][1] = source
+				// pass token to default renderer.
+				return defaultRender(tokens, idx, options, env, self);
+			};
+
 		},
 	},
 

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -73,14 +73,14 @@ export default {
 				}
 
 				token.attrs[aIndex][1] = path
-				path = path.toLowerCase()
+				const lowecasePath = path.toLowerCase()
 				// pass token to default renderer.
-				if (path.endsWith("jpg") ||
-					path.endsWith("jpeg") ||
-					path.endsWith("bmp") ||
-					path.endsWith("webp") ||
-					path.endsWith("gif") ||
-					path.endsWith("png")) {
+				if (lowecasePath.endsWith("jpg") ||
+					lowecasePath.endsWith("jpeg") ||
+					lowecasePath.endsWith("bmp") ||
+					lowecasePath.endsWith("webp") ||
+					lowecasePath.endsWith("gif") ||
+					lowecasePath.endsWith("png")) {
 					return defaultRender(tokens, idx, options, env, self)
 				}else{
 					let dlimgpath = generateUrl('svg/core/actions/download?color=ffffff');

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -18,7 +18,7 @@ export default {
 		noteid: {
 			type: String,
 			required: true,
-		}
+		},
 	},
 
 	data() {
@@ -38,7 +38,7 @@ export default {
 
 		return {
 			html: '',
-			md: markdown
+			md: markdown,
 		}
 	},
 

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -65,7 +65,7 @@ export default {
 				let path = token.attrs[aIndex][1]
 
 				if (!path.startsWith('http')) {
-					path = generateUrl('apps/notes') + '/notes/' + id + '/attachment?path=' + path
+					path = generateUrl('apps/notes/notes/{id}/attachment?path={path}', { id, path })
 				}
 
 				token.attrs[aIndex][1] = path
@@ -80,7 +80,7 @@ export default {
 					return defaultRender(tokens, idx, options, env, self)
 				} else {
 					const dlimgpath = generateUrl('svg/core/actions/download?color=ffffff')
-					return '<div class=\'download-file\'><a href=\'' + path + '\'><div class=\'download-icon\'><img class=\'download-icon-inner\' src=\'' + dlimgpath + '\'>' + token.content + '</div></a></div>'
+					return '<div class="download-file"><a href="' + path.replace(/"/g, '&quot;') + '"><div class="download-icon"><img class="download-icon-inner" src="' + dlimgpath + '">' + token.content + '</div></a></div>'
 				}
 			}
 		},

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -145,5 +145,12 @@ export default {
 			cursor: default;
 		}
 	}
+
+	& img {
+		width: 75%;
+		margin-left: auto;
+		margin-right: auto;
+		display: block;
+	}
 }
 </style>

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -67,16 +67,13 @@ export default {
 				// If you are sure other plugins can't add `target` - drop check below
 				const token = tokens[idx]
 				const aIndex = token.attrIndex('src')
-				let source = token.attrs[aIndex][1]
+				let path = token.attrs[aIndex][1]
 
-				// rewrite dots to ; for url-encoding. See the corresponding API
-				source = source.replaceAll('../', ';;/')
-
-				if (!source.startsWith('http')) {
-					source = generateUrl('apps/notes') + '/notes/image/' + id + '/' + Buffer.from(source, 'utf8').toString('base64');
+				if (!path.startsWith('http')) {
+					path = generateUrl('apps/notes') + '/notes/' + id + '/attachment?path=' + path
 				}
 
-				token.attrs[aIndex][1] = source
+				token.attrs[aIndex][1] = path
 				// pass token to default renderer.
 				return defaultRender(tokens, idx, options, env, self)
 			}

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -73,6 +73,7 @@ export default {
 				}
 
 				token.attrs[aIndex][1] = path
+				path = path.toLowerCase()
 				// pass token to default renderer.
 				if (path.endsWith("jpg") ||
 					path.endsWith("jpeg") ||

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -73,7 +73,7 @@ export default {
 				source = source.replaceAll('../', ';;/')
 
 				if (!source.startsWith('http')) {
-					source = generateUrl('apps/notes') + '/notes/image/' + id + '/' + source
+					source = generateUrl('apps/notes') + '/notes/image/' + id + '/' + Buffer.from(source, 'utf8').toString('base64');
 				}
 
 				token.attrs[aIndex][1] = source

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -75,16 +75,16 @@ export default {
 				token.attrs[aIndex][1] = path
 				const lowecasePath = path.toLowerCase()
 				// pass token to default renderer.
-				if (lowecasePath.endsWith("jpg") ||
-					lowecasePath.endsWith("jpeg") ||
-					lowecasePath.endsWith("bmp") ||
-					lowecasePath.endsWith("webp") ||
-					lowecasePath.endsWith("gif") ||
-					lowecasePath.endsWith("png")) {
+				if (lowecasePath.endsWith('jpg')
+					|| lowecasePath.endsWith('jpeg')
+					|| lowecasePath.endsWith('bmp')
+					|| lowecasePath.endsWith('webp')
+					|| lowecasePath.endsWith('gif')
+					|| lowecasePath.endsWith('png')) {
 					return defaultRender(tokens, idx, options, env, self)
-				}else{
-					let dlimgpath = generateUrl('svg/core/actions/download?color=ffffff');
-					return "<div class='download-file'><a href='"+path+"'><div class='download-icon'><img class='download-icon-inner' src='"+dlimgpath+"'>"+token.content+"</div></a></div>"
+				} else {
+					const dlimgpath = generateUrl('svg/core/actions/download?color=ffffff')
+					return '<div class=\'download-file\'><a href=\'' + path + '\'><div class=\'download-icon\'><img class=\'download-icon-inner\' src=\'' + dlimgpath + '\'>' + token.content + '</div></a></div>'
 				}
 			}
 		},

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -33,8 +33,8 @@ export default {
 		})
 
 		const markdown = new MarkdownIt({
-				linkify: true,
-			});
+			linkify: true,
+		})
 
 		return {
 			html: '',
@@ -59,27 +59,27 @@ export default {
 		setImageRule(id) {
 			// https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
 			// Remember old renderer, if overridden, or proxy to default renderer
-			var defaultRender = this.md.renderer.rules.image || function(tokens, idx, options, env, self) {
-				return self.renderToken(tokens, idx, options);
-			};
+			const defaultRender = this.md.renderer.rules.image || function(tokens, idx, options, env, self) {
+				return self.renderToken(tokens, idx, options)
+			}
 
-			this.md.renderer.rules.image = function (tokens, idx, options, env, self) {
+			this.md.renderer.rules.image = function(tokens, idx, options, env, self) {
 				// If you are sure other plugins can't add `target` - drop check below
-				var aIndex = tokens[idx].attrIndex('src');
-				var source = tokens[idx].attrs[aIndex][1];
+				const token = tokens[idx]
+				const aIndex = token.attrIndex('src')
+				let source = token.attrs[aIndex][1]
 
-				//rewrite dots to ; for url-encoding. See the corresponding API
-				source = source.replaceAll("../", ";;/");
+				// rewrite dots to ; for url-encoding. See the corresponding API
+				source = source.replaceAll('../', ';;/')
 
-				if(!source.startsWith("http")) {
-					source = generateUrl('apps/notes') + "/notes/image/" + id + "/" + source;
+				if (!source.startsWith('http')) {
+					source = generateUrl('apps/notes') + '/notes/image/' + id + '/' + source
 				}
 
-				tokens[idx].attrs[aIndex][1] = source
+				token.attrs[aIndex][1] = source
 				// pass token to default renderer.
-				return defaultRender(tokens, idx, options, env, self);
-			};
-
+				return defaultRender(tokens, idx, options, env, self)
+			}
 		},
 	},
 

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -75,7 +75,17 @@ export default {
 
 				token.attrs[aIndex][1] = path
 				// pass token to default renderer.
-				return defaultRender(tokens, idx, options, env, self)
+				if (path.endsWith("jpg") ||
+					path.endsWith("jpeg") ||
+					path.endsWith("bmp") ||
+					path.endsWith("webp") ||
+					path.endsWith("gif") ||
+					path.endsWith("png")) {
+					return defaultRender(tokens, idx, options, env, self)
+				}else{
+					let dlimgpath = generateUrl('svg/core/actions/download?color=ffffff');
+					return "<div class='download-file'><a href='"+path+"'><div class='download-icon'><img class='download-icon-inner' src='"+dlimgpath+"'>"+token.content+"</div></a></div>"
+				}
 			}
 		},
 	},
@@ -185,5 +195,34 @@ export default {
 		margin-right: auto;
 		display: block;
 	}
+
+	.download-file {
+		width: 75%;
+		margin-left: auto;
+		margin-right: auto;
+		display: block;
+		text-align: center;
+	}
+
+	.download-icon {
+		padding: 15px;
+		margin-left: auto;
+		margin-right: auto;
+		width: 75%;
+		border-radius: 10px;
+		background-color: var(--color-background-dark);
+		border: 1px solid transparent; // so that it does not move on hover
+	}
+
+	.download-icon:hover {
+		border: 1px var(--color-primary-element) solid;
+	}
+
+	.download-icon-inner {
+		height: 3em;
+		width: auto;
+		margin-bottom: 5px;
+	}
+
 }
 </style>

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -27,9 +27,41 @@ export default {
 			liClass: 'task-list-item',
 		})
 
+		const markdown = new MarkdownIt({
+				linkify: true,
+			});
+
+
+		// https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
+		// Remember old renderer, if overridden, or proxy to default renderer
+		var defaultRender = markdown.renderer.rules.image || function(tokens, idx, options, env, self) {
+			return self.renderToken(tokens, idx, options);
+		};
+
+		markdown.renderer.rules.image = function (tokens, idx, options, env, self) {
+			// If you are sure other plugins can't add `target` - drop check below
+			var aIndex = tokens[idx].attrIndex('src');
+			var source = tokens[idx].attrs[aIndex][1];
+
+			//rewrite dots to ; for url-encoding. See the corresponding API
+			source = source.replace("../", ";;/");
+
+			// properly determine main url
+
+			if(!source.startsWith("http")) {
+				source = "http://localhost/index.php/apps/notes/notes/image/199/" + source;
+			}
+
+			tokens[idx].attrs[aIndex][1] = source
+			// pass token to default renderer.
+			return defaultRender(tokens, idx, options, env, self);
+		};
+
+
 		return {
 			html: '',
 			md,
+			md: markdown
 		}
 	},
 

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -38,7 +38,6 @@ export default {
 
 		return {
 			html: '',
-			md,
 			md: markdown
 		}
 	},

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -32,13 +32,9 @@ export default {
 			liClass: 'task-list-item',
 		})
 
-		const markdown = new MarkdownIt({
-			linkify: true,
-		})
-
 		return {
 			html: '',
-			md: markdown,
+			md,
 		}
 	},
 

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -33,6 +33,7 @@
 				<ThePreview v-if="preview" :value="note.content" :noteid="this.noteId" />
 				<TheEditor v-else
 					:value="note.content"
+					:noteid="this.noteId"
 					:readonly="note.readonly"
 					@input="onEdit"
 				/>

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -30,7 +30,7 @@
 				<div v-show="!note.content" class="placeholder">
 					{{ preview ? t('notes', 'Empty note') : t('notes', 'Write …') }}
 				</div>
-				<ThePreview v-if="preview" :value="note.content" />
+				<ThePreview v-if="preview" :value="note.content" :noteid="this.noteId" />
 				<TheEditor v-else
 					:value="note.content"
 					:readonly="note.readonly"

--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -30,10 +30,10 @@
 				<div v-show="!note.content" class="placeholder">
 					{{ preview ? t('notes', 'Empty note') : t('notes', 'Write …') }}
 				</div>
-				<ThePreview v-if="preview" :value="note.content" :noteid="this.noteId" />
+				<ThePreview v-if="preview" :value="note.content" :noteid="noteId" />
 				<TheEditor v-else
 					:value="note.content"
-					:noteid="this.noteId"
+					:noteid="noteId"
 					:readonly="note.readonly"
 					@input="onEdit"
 				/>


### PR DESCRIPTION
Todo, for now see #74 

- [x] Solve upward relative filepaths
- [x] check that only the users own files are accessible
- [ ] ~~allow arbitrary files to be linked, not only images~~ (This is not really supported by markdown afaik)
- [x] fix generation of clientside url for api access
- [x] add upload-api
- [x] add upload-ui
- [ ] ~~maybe add error-image to display anything at all when image not resolvable~~ (not the job of the service)
- [x] fix aaaaaall the stlye issues
- [x] Add Documentation
- [x] imageproxy can't resolve subdirectories (probably because the route does not match anymore with additional /)


~~We should have a serious discussion about the proxy. Currently it allows to get ALL files from files, even outside of the Notes-folder. We may want to restrict access to Files somewhere accessible to the notes app, not all over the instance.~~
Currently only files in the Notes-basefolder are accessible. This removes all security issues posed by allowing abitrary paths.

Also, because of how urls are encoded, `../` is beeing removed (from the url). Therefore, the api only accepts `;;/` as a substitute, and all clients need to replace the  `../` syntax before rendering the link (i am open for suggestions on how to fix this). The markdown-sourcefile **does not need** to be modified, and is not beeing modified by this.