### PR TITLE
add 'markdown-it-task-checkbox' dependency to render checkboxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "notes",
 			"license": "agpl",
 			"dependencies": {
 				"@nextcloud/axios": "^1.7.0",
@@ -17,6 +16,7 @@
 				"diff": "^5.0.0",
 				"easymde": "^2.15.0",
 				"markdown-it": "^12.2.0",
+				"markdown-it-task-checkbox": "^1.0.6",
 				"vue": "^2.6.14",
 				"vue-fragment": "1.5.1",
 				"vue-material-design-icons": "^4.13.0",
@@ -8001,6 +8001,11 @@
 			"bin": {
 				"markdown-it": "bin/markdown-it.js"
 			}
+		},
+		"node_modules/markdown-it-task-checkbox": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/markdown-it-task-checkbox/-/markdown-it-task-checkbox-1.0.6.tgz",
+			"integrity": "sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw=="
 		},
 		"node_modules/markdown-it/node_modules/argparse": {
 			"version": "2.0.1",
@@ -18923,6 +18928,11 @@
 					"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
 				}
 			}
+		},
+		"markdown-it-task-checkbox": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/markdown-it-task-checkbox/-/markdown-it-task-checkbox-1.0.6.tgz",
+			"integrity": "sha512-7pxkHuvqTOu3iwVGmDPeYjQg+AIS9VQxzyLP9JCg9lBjgPAJXGEkChK6A2iFuj3tS0GV3HG2u5AMNhcQqwxpJw=="
 		},
 		"marked": {
 			"version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"diff": "^5.0.0",
 		"easymde": "^2.15.0",
 		"markdown-it": "^12.2.0",
+		"markdown-it-task-checkbox": "^1.0.6",
 		"vue": "^2.6.14",
 		"vue-fragment": "1.5.1",
 		"vue-material-design-icons": "^4.13.0",

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -17,11 +17,19 @@ export default {
 	},
 
 	data() {
+
+		const md = new MarkdownIt({
+			linkify: true,
+		})
+
+		md.use(require('markdown-it-task-checkbox'), {
+			disabled: true,
+			liClass: 'task-list-item'
+		})
+
 		return {
 			html: '',
-			md: new MarkdownIt({
-				linkify: true,
-			}),
+			md
 		}
 	},
 
@@ -126,6 +134,13 @@ export default {
 
 	& table td:empty::after {
 		content: '\00a0';
+	}
+
+	.task-list-item {
+		list-style-type: none;
+		input {
+			min-height: initial !important;
+		}
 	}
 }
 </style>

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -24,12 +24,12 @@ export default {
 
 		md.use(require('markdown-it-task-checkbox'), {
 			disabled: true,
-			liClass: 'task-list-item'
+			liClass: 'task-list-item',
 		})
 
 		return {
 			html: '',
-			md
+			md,
 		}
 	},
 
@@ -140,6 +140,9 @@ export default {
 		list-style-type: none;
 		input {
 			min-height: initial !important;
+		}
+		label {
+			cursor: default;
 		}
 	}
 }


### PR DESCRIPTION
fixes #325


this does not allow for using checkboxes from the markdown viewer. I would like to implement such a feature, but that probably requires a change in the upstream library.