### PR TITLE
require at least PHP 7.4

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@ The Notes app is a distraction free notes taking app for [Nextcloud](https://www
 	<repository type="git">https://github.com/nextcloud/notes.git</repository>
 	<screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
 	<dependencies>
-		<php min-version="7.3" max-version="8.1" />
+		<php min-version="7.4" max-version="8.1" />
 		<nextcloud min-version="22" max-version="25" />
 	</dependencies>
 	<repair-steps>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,7 +12,7 @@ use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'notes';
-	public static $API_VERSIONS = [ '0.2', '1.2' ];
+	public static array $API_VERSIONS = [ '0.2', '1.2' ];
 
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);

--- a/lib/AppInfo/Capabilities.php
+++ b/lib/AppInfo/Capabilities.php
@@ -8,15 +8,13 @@ use OCP\Capabilities\ICapability;
 use OCP\App\IAppManager;
 
 class Capabilities implements ICapability {
-
-	/** @var IAppManager */
-	private $appManager;
+	private IAppManager $appManager;
 
 	public function __construct(IAppManager $appManager) {
 		$this->appManager = $appManager;
 	}
 
-	public function getCapabilities() {
+	public function getCapabilities(): array {
 		return [
 			Application::APP_ID => [
 				'api_version' => Application::$API_VERSIONS,

--- a/lib/AppInfo/DashboardWidget.php
+++ b/lib/AppInfo/DashboardWidget.php
@@ -9,11 +9,8 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 
 class DashboardWidget implements IWidget {
-
-	/** @var IURLGenerator */
-	private $url;
-	/** @var IL10N */
-	private $l10n;
+	private IURLGenerator $url;
+	private IL10N $l10n;
 
 	public function __construct(
 		IURLGenerator $url,

--- a/lib/AppInfo/NotesHooks.php
+++ b/lib/AppInfo/NotesHooks.php
@@ -12,9 +12,9 @@ use OCP\Files\Node;
 use Psr\Log\LoggerInterface;
 
 class NotesHooks {
-	private $logger;
-	private $rootFolder;
-	private $metaService;
+	private LoggerInterface $logger;
+	private IRootFolder $rootFolder;
+	private MetaService $metaService;
 
 	public function __construct(
 		LoggerInterface $logger,

--- a/lib/AppInfo/SearchProvider.php
+++ b/lib/AppInfo/SearchProvider.php
@@ -16,13 +16,9 @@ use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 
 class SearchProvider implements IProvider {
-
-	/** @var Util */
-	private $util;
-	/** @var NotesService */
-	private $notesService;
-	/** @var IURLGenerator */
-	private $url;
+	private Util $util;
+	private NotesService $notesService;
+	private IURLGenerator $url;
 
 	public function __construct(
 		Util $util,

--- a/lib/Controller/ChunkCursor.php
+++ b/lib/Controller/ChunkCursor.php
@@ -7,12 +7,9 @@ namespace OCA\Notes\Controller;
 use OCA\Notes\Service\MetaNote;
 
 class ChunkCursor {
-	/** @var \DateTime */
-	public $timeStart;
-	/** @var integer */
-	public $noteLastUpdate;
-	/** @var integer */
-	public $noteId;
+	public \DateTime $timeStart;
+	public int $noteLastUpdate;
+	public int $noteId;
 
 	public static function fromString(string $str) : ?ChunkCursor {
 		if (preg_match('/^(\d+)-(\d+)-(\d+)$/', $str, $matches)) {
@@ -30,7 +27,7 @@ class ChunkCursor {
 	public static function fromNote(\DateTime $timeStart, MetaNote $m) : ChunkCursor {
 		$cc = new static();
 		$cc->timeStart = $timeStart;
-		$cc->noteLastUpdate = $m->meta->getLastUpdate();
+		$cc->noteLastUpdate = (int)$m->meta->getLastUpdate();
 		$cc->noteId = $m->note->getId();
 		return $cc;
 	}

--- a/lib/Controller/ETagDoesNotMatchException.php
+++ b/lib/Controller/ETagDoesNotMatchException.php
@@ -9,7 +9,7 @@ use OCA\Notes\Service\Note;
 use Exception;
 
 class ETagDoesNotMatchException extends Exception {
-	public $note;
+	public Note $note;
 
 	public function __construct(Note $note) {
 		$this->note = $note;

--- a/lib/Controller/Helper.php
+++ b/lib/Controller/Helper.php
@@ -20,15 +20,10 @@ use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class Helper {
-
-	/** @var NotesService */
-	private $notesService;
-	/** @var MetaService */
-	private $metaService;
-	/** @var LoggerInterface */
-	public $logger;
-	/** @var IUserSession */
-	private $userSession;
+	private NotesService $notesService;
+	private MetaService $metaService;
+	public LoggerInterface $logger;
+	private IUserSession $userSession;
 
 	public function __construct(
 		NotesService $notesService,

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -15,15 +15,10 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
 class NotesApiController extends ApiController {
-
-	/** @var NotesService */
-	private $service;
-	/** @var MetaService */
-	private $metaService;
-	/** @var SettingsService */
-	private $settingsService;
-	/** @var Helper */
-	private $helper;
+	private NotesService $service;
+	private MetaService $metaService;
+	private SettingsService $settingsService;
+	private Helper $helper;
 
 	public function __construct(
 		string $AppName,
@@ -228,7 +223,7 @@ class NotesApiController extends ApiController {
 	 * @CORS
 	 * @NoCSRFRequired
 	 */
-	public function setSettings() {
+	public function setSettings() : JSONResponse {
 		return $this->helper->handleErrorResponse(function () {
 			$this->settingsService->set($this->helper->getUID(), $this->request->getParams());
 			return $this->getSettings();
@@ -240,7 +235,7 @@ class NotesApiController extends ApiController {
 	 * @CORS
 	 * @NoCSRFRequired
 	 */
-	public function getSettings() {
+	public function getSettings() : JSONResponse {
 		return $this->helper->handleErrorResponse(function () {
 			return $this->settingsService->getAll($this->helper->getUID());
 		});

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -17,19 +17,12 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 
 class NotesController extends Controller {
-
-	/** @var NotesService */
-	private $notesService;
-	/** @var MetaService */
-	private $metaService;
-	/** @var SettingsService */
-	private $settingsService;
-	/** @var Helper */
-	private $helper;
-	/** @var IConfig */
-	private $settings;
-	/** @var IL10N */
-	private $l10n;
+	private NotesService $notesService;
+	private MetaService $metaService;
+	private SettingsService $settingsService;
+	private Helper $helper;
+	private IConfig $settings;
+	private IL10N $l10n;
 
 	public function __construct(
 		string $AppName,

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -15,12 +15,9 @@ use OCP\IURLGenerator;
 use OCP\IUserSession;
 
 class PageController extends Controller {
-	/** @NotesService */
-	private $notesService;
-	/** @var IUserSession */
-	private $userSession;
-	/** @IURLGenerator */
-	private $urlGenerator;
+	private NotesService $notesService;
+	private IUserSession $userSession;
+	private IURLGenerator $urlGenerator;
 
 	public function __construct(
 		string $AppName,

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -12,8 +12,8 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 class SettingsController extends Controller {
-	private $service;
-	private $userSession;
+	private SettingsService $service;
+	private IUserSession $userSession;
 
 	public function __construct(
 		string $appName,
@@ -26,7 +26,7 @@ class SettingsController extends Controller {
 		$this->userSession = $userSession;
 	}
 
-	private function getUID() {
+	private function getUID(): string {
 		return $this->userSession->getUser()->getUID();
 	}
 
@@ -34,7 +34,7 @@ class SettingsController extends Controller {
 	 * @NoAdminRequired
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function set() {
+	public function set(): JSONResponse {
 		$this->service->set(
 			$this->getUID(),
 			$this->request->getParams()
@@ -45,7 +45,7 @@ class SettingsController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 */
-	public function get() {
+	public function get(): JSONResponse {
 		return new JSONResponse($this->service->getAll($this->getUID()));
 	}
 }

--- a/lib/Migration/Cleanup.php
+++ b/lib/Migration/Cleanup.php
@@ -10,7 +10,7 @@ use OCP\Migration\IRepairStep;
 use OCP\Migration\IOutput;
 
 class Cleanup implements IRepairStep {
-	private $metaMapper;
+	private MetaMapper $metaMapper;
 
 	public function __construct(MetaMapper $metaMapper) {
 		$this->metaMapper = $metaMapper;
@@ -19,14 +19,14 @@ class Cleanup implements IRepairStep {
 	/*
 	 * @inheritdoc
 	 */
-	public function getName() {
+	public function getName(): string {
 		return 'Clean up meta table';
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	public function run(IOutput $output) {
+	public function run(IOutput $output): void {
 		$this->metaMapper->deleteAll();
 	}
 }

--- a/lib/Service/MetaNote.php
+++ b/lib/Service/MetaNote.php
@@ -7,10 +7,8 @@ namespace OCA\Notes\Service;
 use OCA\Notes\Db\Meta;
 
 class MetaNote {
-	/** @var Note */
-	public $note;
-	/** @var Meta */
-	public $meta;
+	public Note $note;
+	public Meta $meta;
 
 	public function __construct(Note $note, Meta $meta) {
 		$this->note = $note;

--- a/lib/Service/MetaService.php
+++ b/lib/Service/MetaService.php
@@ -49,8 +49,8 @@ use OCA\Notes\Db\MetaMapper;
  * with this approach! :-)
  */
 class MetaService {
-	private $metaMapper;
-	private $util;
+	private MetaMapper $metaMapper;
+	private Util $util;
 
 	public function __construct(MetaMapper $metaMapper, Util $util) {
 		$this->metaMapper = $metaMapper;

--- a/lib/Service/Note.php
+++ b/lib/Service/Note.php
@@ -8,12 +8,10 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 
 class Note {
-	private $file;
-	private $notesFolder;
-	/** @var NoteUtil */
-	private $noteUtil;
-	/** @var Util */
-	private $util;
+	private File $file;
+	private Folder $notesFolder;
+	private NoteUtil $noteUtil;
+	private Util $util;
 
 	public function __construct(File $file, Folder $notesFolder, NoteUtil $noteUtil) {
 		$this->file = $file;

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -11,12 +11,10 @@ use OCP\IDBConnection;
 
 class NoteUtil {
 	private const MAX_TITLE_LENGTH = 100;
-	/** @var Util */
-	public $util;
-	private $db;
-	private $root;
-	private $tagService;
-	private $cachedTags;
+	public Util $util;
+	private IDBConnection $db;
+	private IRootFolder $root;
+	private TagService $tagService;
 
 	public function __construct(
 		Util $util,

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -10,9 +10,9 @@ use OCP\Files\Folder;
 use OCP\Files\NotPermittedException;
 
 class NotesService {
-	private $metaService;
-	private $settings;
-	private $noteUtil;
+	private MetaService $metaService;
+	private SettingsService $settings;
+	private NoteUtil $noteUtil;
 
 	public function __construct(
 		MetaService $metaService,

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -11,12 +11,12 @@ use OCP\IL10N;
 use OCP\Files\IRootFolder;
 
 class SettingsService {
-	private $config;
-	private $l10n;
-	private $root;
+	private IConfig $config;
+	private IL10N $l10n;
+	private IRootFolder $root;
 
 	/* Allowed attributes */
-	private $attrs;
+	private array $attrs;
 
 	public function __construct(
 		IConfig $config,

--- a/lib/Service/TagService.php
+++ b/lib/Service/TagService.php
@@ -8,9 +8,7 @@ use OCP\ITagManager;
 use OCP\ITags;
 
 class TagService {
-	/** @var ITags */
-	private $tagger;
-	/** @var array */
+	private ?ITags $tagger;
 	private $cachedTags;
 
 	public function __construct(ITagManager $tagManager) {

--- a/lib/Service/Util.php
+++ b/lib/Service/Util.php
@@ -9,10 +9,8 @@ use OCP\IL10N;
 use Psr\Log\LoggerInterface;
 
 class Util {
-	/** @var IL10N */
-	public $l10n;
-	/** @var LoggerInterface */
-	public $logger;
+	public IL10N $l10n;
+	public LoggerInterface $logger;
 
 	public function __construct(
 		IL10N $l10n,

--- a/tests/api/APIv1Test.php
+++ b/tests/api/APIv1Test.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OCA\Notes\Tests\API;
 
 class APIv1Test extends CommonAPITest {
-	protected $requiredSettings = [
+	protected array $requiredSettings = [
 		'notesPath' => 'string',
 		'fileSuffix' => 'string',
 	];

--- a/tests/api/AbstractAPITest.php
+++ b/tests/api/AbstractAPITest.php
@@ -7,8 +7,8 @@ namespace OCA\Notes\Tests\API;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractAPITest extends TestCase {
-	protected $apiVersion;
-	protected $http;
+	protected string $apiVersion;
+	protected \GuzzleHttp\Client $http;
 
 	public function __construct(string $apiVersion) {
 		parent::__construct();

--- a/tests/api/CapabilitiesTest.php
+++ b/tests/api/CapabilitiesTest.php
@@ -7,7 +7,7 @@ namespace OCA\Notes\Tests\API;
 use PHPUnit\Framework\TestCase;
 
 class CapabilitiesTest extends TestCase {
-	protected $http;
+	protected \GuzzleHttp\Client $http;
 
 	protected function setUp() : void {
 		$this->http = new \GuzzleHttp\Client([

--- a/tests/api/CommonAPITest.php
+++ b/tests/api/CommonAPITest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OCA\Notes\Tests\API;
 
 abstract class CommonAPITest extends AbstractAPITest {
-	private $requiredAttributes = [
+	private array $requiredAttributes = [
 		'id' => 'integer',
 		'readonly' => 'boolean',
 		'content' => 'string',
@@ -16,7 +16,7 @@ abstract class CommonAPITest extends AbstractAPITest {
 		'etag' => 'string',
 	];
 
-	private $autotitle;
+	private bool $autotitle;
 
 	public function __construct(string $apiVersion, bool $autotitle) {
 		parent::__construct($apiVersion);


### PR DESCRIPTION
This PR drops support for PHP 7.3 and requires at least PHP 7.4.

Since PHP 7.3 is not maintained anymore since 12.2021, this does not imply a major release.

This PR makes also use from typed class properties, which where introduced in PHP 7.4.