### PR TITLE
Enable admins to set the settings defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ Before reporting bugs:
 ### REST API for third-party apps
 
 The notes app provides a JSON-API for third-party apps. Please have a look at our **[API documentation](docs/api/README.md)**.
+
+
+### Admin configuration
+
+It is possible to specify different defaults for the notes settings of new users using `occ` commands like these:
+
+```
+occ config:app:set notes noteMode --value="preview"
+occ config:app:set notes fileSuffix --value=".md"
+occ config:app:set notes defaultFolder --value="Shared notes"
+```
+
+| Setting | Property name | Default | Other available option(s) |
+|---------|---------------|---------|---------------------------|
+| Display mode for notes | noteMode | .edit | .preview |
+| File extension for new notes | fileSuffix | .txt | .md |
+| Folder to store your notes | defaultFolder | Notes | _Custom_ |

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -29,7 +29,7 @@ class SettingsService {
 		$this->l10n = $l10n;
 		$this->root = $root;
 		$this->attrs = [
-			'fileSuffix' => $this->getListAttrs(...[...$this->defaultSuffixes, 'custom']),
+			'fileSuffix' => $this->getListAttrs('fileSuffix', [...$this->defaultSuffixes, 'custom']),
 			'notesPath' => [
 				'default' => function (string $uid) {
 					return $this->getDefaultNotesPath($uid);
@@ -48,7 +48,7 @@ class SettingsService {
 					return implode(DIRECTORY_SEPARATOR, $path);
 				},
 			],
-			'noteMode' => $this->getListAttrs('edit', 'preview'),
+			'noteMode' => $this->getListAttrs('noteMode', ['edit', 'preview']),
 			'customSuffix' => [
 				'default' => $this->defaultSuffixes[0],
 				'validate' => function ($value) {
@@ -62,22 +62,23 @@ class SettingsService {
 		];
 	}
 
-	private function getListAttrs(...$values) : array {
-		$first = $values[0];
+	private function getListAttrs(string $attributeName, array $values) : array {
+		$default = $this->config->getAppValue(Application::APP_ID, $attributeName, $values[0]);
+
 		return [
-			'default' => $first,
-			'validate' => function ($value) use ($values, $first) {
+			'default' => $default,
+			'validate' => function ($value) use ($values, $default) {
 				if (in_array($value, $values)) {
 					return $value;
 				} else {
-					return $first;
+					return $default;
 				}
 			},
 		];
 	}
 
 	private function getDefaultNotesPath(string $uid) : string {
-		$defaultFolder = 'Notes';
+		$defaultFolder = $this->config->getAppValue(Application::APP_ID, 'defaultFolder', 'Notes');
 		$defaultExists = $this->root->getUserFolder($uid)->nodeExists($defaultFolder);
 		if ($defaultExists) {
 			return $defaultFolder;


### PR DESCRIPTION
I needed to be able to customize the defaults of Note settings (i.e. name of folder to store notes in, file extension, and display mode).

Mainly because in my case, it's poor UX for users to jump directly into edit mode when browsing notes (articles), and `.md` always makes more sense than `.txt`.

It can now be done using `occ` like this:

```
occ config:app:set notes noteMode --value="preview"
occ config:app:set notes fileSuffix --value=".md"
occ config:app:set notes defaultFolder --value="Wiki"
```

a GUI in admin settings may be added later.

fixes #629