### PR TITLE
fix: Avoid undefined variable

### DIFF
--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -146,6 +146,7 @@ class NoteUtil {
 	 * @return Folder
 	 */
 	public function getOrCreateFolder(string $path, bool $create = true) : Folder {
+		$folder = null;
 		if ($this->root->nodeExists($path)) {
 			$folder = $this->root->get($path);
 		} elseif ($create) {


### PR DESCRIPTION
fixes https://github.com/nextcloud/notes/issues/976

This could happen if search tries ot get the notes folder but it hasn't been created yet (and should not through the serarch request)
