### PR TITLE
fix: Ensure to fallback to old editor properly on 25

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -6,6 +6,7 @@ namespace OCA\Notes\Service;
 
 use OCA\Notes\AppInfo\Application;
 
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\Files\IRootFolder;
@@ -14,6 +15,7 @@ class SettingsService {
 	private IConfig $config;
 	private IL10N $l10n;
 	private IRootFolder $root;
+	private IAppManager $appManager;
 
 	/* Allowed attributes */
 	private array $attrs;
@@ -23,11 +25,13 @@ class SettingsService {
 	public function __construct(
 		IConfig $config,
 		IL10N $l10n,
-		IRootFolder $root
+		IRootFolder $root,
+		IAppManager $appManager
 	) {
 		$this->config = $config;
 		$this->l10n = $l10n;
 		$this->root = $root;
+		$this->appManager = $appManager;
 		$this->attrs = [
 			'fileSuffix' => $this->getListAttrs('fileSuffix', [...$this->defaultSuffixes, 'custom']),
 			'notesPath' => [
@@ -48,7 +52,7 @@ class SettingsService {
 					return implode(DIRECTORY_SEPARATOR, $path);
 				},
 			],
-			'noteMode' => $this->getListAttrs('noteMode', ['rich', 'edit', 'preview']),
+			'noteMode' => $this->getListAttrs('noteMode', $this->getAvailableEditorModes()),
 			'customSuffix' => [
 				'default' => $this->defaultSuffixes[0],
 				'validate' => function ($value) {
@@ -181,5 +185,11 @@ class SettingsService {
 		}
 		unset($settings->customSuffix);
 		return $settings;
+	}
+
+	private function getAvailableEditorModes(): array {
+		return \OCP\Util::getVersion()[0] >= 26 && $this->appManager->isEnabledForUser('text')
+			? ['rich', 'edit', 'preview']
+			: ['edit', 'preview'];
 	}
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -101,7 +101,7 @@ export default {
 			deletedNotes: [],
 			refreshTimer: null,
 			helpVisible: false,
-			editorHint: loadState('notes', 'editorHint', '') === 'yes' && window.oc_appswebroots.text,
+			editorHint: loadState('notes', 'editorHint', '') === 'yes' && window.OCA.Text?.createEditor,
 		}
 	},
 

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -83,6 +83,9 @@ export default {
 	},
 
 	created() {
+		if (!window.OCA.Text?.createEditor) {
+			this.noteModes.splice(0, 1)
+		}
 	},
 
 	methods: {


### PR DESCRIPTION
Fixes #982 

I was missing the case where the text is enabled but still on 25 meaning that createEditor is not available.