### PR TITLE
fix: Allow migration endpoint to be called by non-admins

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -49,6 +49,9 @@ class SettingsController extends Controller {
 		return new JSONResponse($this->service->getAll($this->getUID()));
 	}
 
+	/**
+	 * @NoAdminRequired
+	 */
 	public function migrate(): JSONResponse {
 		$this->service->delete($this->getUID(), 'editorHint');
 		return new JSONResponse();


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
