### PR TITLE
Category: Add new category button to create new folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.8.1",
       "license": "agpl",
       "dependencies": {
+        "@nextcloud/auth": "^2.2.1",
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/dialogs": "^4.2.1",
         "@nextcloud/event-bus": "^3.1.0",
@@ -3099,15 +3100,15 @@
       "integrity": "sha512-rxzuSL2RSt/pWWnFnUFQi5GJArm2tHMhx20Gee3Ydn+xT2bqbR4syfgdPrq2b+j+n5LjC7C8Fb1QDM6LKeF0cA=="
     },
     "node_modules/@nextcloud/auth": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.1.0.tgz",
-      "integrity": "sha512-wf5xQrWQu6fkl3MGegVdyR5mh/EdSQKJByH3m2Url2K2xbML9Y4Y7LAff9jjJAcMt2MkzzJEM463ZBbgTqs0lg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
+      "integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
       "dependencies": {
         "@nextcloud/event-bus": "^3.1.0"
       },
       "engines": {
-        "node": "^16.0.0",
-        "npm": "^7.0.0 || ^8.0.0"
+        "node": "^20.0.0",
+        "npm": "^9.0.0"
       }
     },
     "node_modules/@nextcloud/axios": {
@@ -19995,9 +19996,9 @@
       "integrity": "sha512-rxzuSL2RSt/pWWnFnUFQi5GJArm2tHMhx20Gee3Ydn+xT2bqbR4syfgdPrq2b+j+n5LjC7C8Fb1QDM6LKeF0cA=="
     },
     "@nextcloud/auth": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.1.0.tgz",
-      "integrity": "sha512-wf5xQrWQu6fkl3MGegVdyR5mh/EdSQKJByH3m2Url2K2xbML9Y4Y7LAff9jjJAcMt2MkzzJEM463ZBbgTqs0lg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
+      "integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
       "requires": {
         "@nextcloud/event-bus": "^3.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "stylelint:fix": "stylelint 'src/**/*.vue' 'css/**/*.css' --fix"
   },
   "dependencies": {
+    "@nextcloud/auth": "^2.2.1",
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/dialogs": "^4.2.1",
     "@nextcloud/event-bus": "^3.1.0",

--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -341,7 +341,7 @@ export const setFavorite = (noteId, favorite) => {
 
 export const findCategory = (categoryName) => {
 	return axios
-		.get(generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${store.state.app.settings.notesPath}${categoryName}`))
+		.get(generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${store.state.app.settings.notesPath}/${categoryName}`))
 		.then(response => {
 			return categoryName
 		})
@@ -360,10 +360,11 @@ export const createCategory = (categoryName) => {
 	// Axios MKCOL workaround: https://github.com/axios/axios/issues/2220
 	return axios
 		.request({
-			url: generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${store.state.app.settings.notesPath}${categoryName}`),
+			url: generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${store.state.app.settings.notesPath}/${categoryName}`),
 			method: 'MKCOL',
 		})
 		.then(response => {
+			store.commit('addCategory', categoryName)
 			return categoryName
 		})
 		.catch(err => {

--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -1,5 +1,6 @@
 import axios from '@nextcloud/axios'
-import { generateUrl } from '@nextcloud/router'
+import { getCurrentUser } from '@nextcloud/auth'
+import { generateUrl, generateRemoteUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
 
 import store from './store.js'
@@ -334,6 +335,40 @@ export const setFavorite = (noteId, favorite) => {
 		.catch(err => {
 			console.error(err)
 			handleSyncError(t('notes', 'Toggling favorite for note {id} has failed.', { id: noteId }), err)
+			throw err
+		})
+}
+
+export const findCategory = (categoryName) => {
+	return axios
+		.get(generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${store.state.app.settings.notesPath}${categoryName}`))
+		.then(response => {
+			return categoryName
+		})
+		.catch(err => {
+			if (err?.response?.status === 404) {
+				return false
+			} else {
+				console.error(err)
+				handleSyncError(t('notes', 'Fetching category {name} has failed.', { name: categoryName }), err)
+				throw err
+			}
+		})
+}
+
+export const createCategory = (categoryName) => {
+	// Axios MKCOL workaround: https://github.com/axios/axios/issues/2220
+	return axios
+		.request({
+			url: generateRemoteUrl(`dav/files/${getCurrentUser().uid}/${store.state.app.settings.notesPath}${categoryName}`),
+			method: 'MKCOL',
+		})
+		.then(response => {
+			return categoryName
+		})
+		.catch(err => {
+			console.error(err)
+			handleSyncError(t('notes', 'Creating new category {name} has failed.', { name: categoryName }), err)
 			throw err
 		})
 }

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -1,5 +1,38 @@
 <template>
 	<Fragment>
+
+	<NcAppNavigationItem
+		:title="title"
+		class="app-navigation-noclose separator-below"
+		:class="{ 'category-header': selectedCategory !== null }"
+		:open.sync="open"
+		:menu-open.sync="menuOpen"
+		:allow-collapse="true"
+		@click.prevent.stop="onToggleCategories"
+	>
+		<template #menu-icon>
+			<AddIcon :size="20" @click="onToggleNewCategory" />
+		</template>
+		<template #actions>
+			<NcActionText>
+				<template #icon>
+					<ErrorIcon v-if="createCategoryError" :size="20" />
+					<AddIcon v-else-if="!createCategoryError" :size="20" />
+				</template>
+				{{ createCategoryError ? createCategoryError : t('notes', 'Create a new category') }}
+			</NcActionText>
+			<NcActionInput
+				icon=""
+				:value="t('notes', 'Category name')"
+				@submit.prevent.stop="createNewCategory"
+			>
+				<template #icon>
+					<FolderIcon :size="20" />
+				</template>
+			</NcActionInput>
+		</template>
+
+		<FolderIcon slot="icon" :size="20" />
 		<NcAppNavigationItem
 			:title="t('notes', 'All notes')"
 			:class="{ active: selectedCategory === null }"
@@ -31,6 +64,8 @@
 
 <script>
 import {
+	NcActionInput,
+	NcActionText,
 	NcAppNavigationItem,
 	NcAppNavigationCaption,
 	NcAppNavigationCounter,
@@ -40,8 +75,10 @@ import { Fragment } from 'vue-fragment'
 import FolderIcon from 'vue-material-design-icons/Folder.vue'
 import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
 import HistoryIcon from 'vue-material-design-icons/History.vue'
+import AddIcon from 'vue-material-design-icons/Plus.vue'
+import ErrorIcon from 'vue-material-design-icons/AlertCircle.vue'
 
-import { getCategories } from '../NotesService.js'
+import { createCategory, findCategory, getCategories } from '../NotesService.js'
 import { categoryLabel } from '../Util.js'
 import store from '../store.js'
 
@@ -56,6 +93,18 @@ export default {
 		FolderIcon,
 		FolderOutlineIcon,
 		HistoryIcon,
+		AddIcon,
+		ErrorIcon,
+		NcActionInput,
+		NcActionText,
+	},
+
+	data() {
+		return {
+			open: false,
+			menuOpen: false,
+			createCategoryError: null,
+		}
 	},
 
 	computed: {
@@ -77,8 +126,36 @@ export default {
 			return categoryLabel(category)
 		},
 
+		onToggleCategories() {
+			this.open = !this.open
+		},
+
+		onToggleNewCategory() {
+			this.menuOpen = !this.menuOpen
+		},
+
 		onSelectCategory(category) {
 			store.commit('setSelectedCategory', category)
+		},
+
+		createNewCategory(event) {
+			const input = event.target.querySelector('input[type=text]')
+			const categoryName = input.value.trim()
+
+			// Check if already exists
+			findCategory(categoryName).then(data => {
+				if (data !== false) {
+					this.createCategoryError = t('notes', 'This category already exists')
+					return
+				}
+
+				// Create new directory for category in current notes path defined in settings
+				createCategory(categoryName)
+				this.createCategoryError = null
+				this.onToggleNewCategory()
+				this.onSelectCategory(categoryName)
+			})
+
 		},
 	},
 }

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -1,37 +1,5 @@
 <template>
 	<Fragment>
-
-	<NcAppNavigationItem
-		:title="title"
-		class="app-navigation-noclose separator-below"
-		:class="{ 'category-header': selectedCategory !== null }"
-		:open.sync="open"
-		:menu-open.sync="menuOpen"
-		:allow-collapse="true"
-		@click.prevent.stop="onToggleCategories"
-	>
-		<template #menu-icon>
-			<AddIcon :size="20" @click="onToggleNewCategory" />
-		</template>
-		<template #actions>
-			<NcActionText>
-				<template #icon>
-					<ErrorIcon v-if="createCategoryError" :size="20" />
-					<AddIcon v-else-if="!createCategoryError" :size="20" />
-				</template>
-				{{ createCategoryError ? createCategoryError : t('notes', 'Create a new category') }}
-			</NcActionText>
-			<NcActionInput
-				icon=""
-				:value="t('notes', 'Category name')"
-				@submit.prevent.stop="createNewCategory"
-			>
-				<template #icon>
-					<FolderIcon :size="20" />
-				</template>
-			</NcActionInput>
-		</template>
-
 		<FolderIcon slot="icon" :size="20" />
 		<NcAppNavigationItem
 			:title="t('notes', 'All notes')"
@@ -44,7 +12,29 @@
 			</NcAppNavigationCounter>
 		</NcAppNavigationItem>
 
-		<NcAppNavigationCaption :title="t('notes', 'Categories')" />
+		<NcAppNavigationCaption :title="t('notes', 'Categories')">
+			<template #actionsTriggerIcon>
+				<AddIcon slot="icon" :size="20" />
+			</template>
+			<template #actions>
+				<NcActionText>
+					<template #icon>
+						<ErrorIcon v-if="createCategoryError" :size="20" />
+						<AddIcon v-else-if="!createCategoryError" :size="20" />
+					</template>
+					{{ createCategoryError ? createCategoryError : t('notes', 'Create a new category') }}
+				</NcActionText>
+				<NcActionInput
+					icon=""
+					:value="t('notes', 'Category name')"
+					@submit.prevent.stop="createNewCategory"
+				>
+					<template #icon>
+						<FolderIcon :size="20" />
+					</template>
+				</NcActionInput>
+			</template>
+		</NcAppNavigationCaption>
 
 		<NcAppNavigationItem v-for="category in categories"
 			:key="category.name"

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -179,6 +179,10 @@ const mutations = {
 		state.categories = categories
 	},
 
+	addCategory(state, category) {
+		state.categories.push(category)
+	},
+
 	setSelectedCategory(state, category) {
 		state.selectedCategory = category
 	},


### PR DESCRIPTION
Following #967 I added an action in the navigation item `Categories` for adding new folders in the current notes path acting as categories.

Some remarks:
- I used the `remote.php` api end-point like the files app, but I am unsure if there is a more elegant way https://github.com/nextcloud/server/blob/55ba9601f2ef5b14524693a77c59cb7f7174270c/apps/files/src/utils/davUtils.js
- I wanted to use `NcActionInput` like the calendar app, but I had trouble to get the trailing submit arrow working, because it only works if the value isn't empty at rendering.. https://github.com/nextcloud/nextcloud-vue/blob/c269d6a3c255f6c62cdefe9407f3756911ee8964/src/components/NcActionInput/NcActionInput.vue#L221
- The Category list does not display empty folder, after creating a category I seleted it so that the success is visible, but if no note is added, the category will vanished from the list until a note is added this category
- The category list will count wills in folder even they are not matching the select file suffix
- Opening the add menu is possible without expanding the category list (just shown in gif differently)

This gifs show the workflow and an error case, if a folder with that name already exist (but may not listed in categories if the folder is empty)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/10757520/227645600-99491a5f-ea05-414f-89ad-79243d1e0296.gif)
