### PR TITLE
Use the color-primary-element* variables

### DIFF
--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -85,6 +85,6 @@ export default {
 </script>
 <style scoped>
 .app-navigation-entry-wrapper.active:deep(.app-navigation-entry) {
-	background-color: var(--color-primary-light) !important;
+	background-color: var(--color-primary-element-light) !important;
 }
 </style>

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -269,7 +269,7 @@ export default {
 /* text selection */
 .CodeMirror .CodeMirror-selectedtext {
 	background-color: var(--color-primary-element) !important;
-	color: var(--color-primary-text) !important;
+	color: var(--color-primary-element-text) !important;
 	opacity: 1 !important;
 }
 

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -239,7 +239,7 @@ export default {
 
 .note-error {
 	background-color: var(--color-error);
-	color: var(--color-primary-text);
+	color: var(--color-primary-element-text);
 	border-radius: 0.5ex;
 	padding: 0.5ex 1ex;
 }


### PR DESCRIPTION
Explanation: the color-primary variables are not to be used in components because the introduce problems with high-contrast primary colors. Fix this by using the primary-element variables instead.