### PR TITLE
fix: Wrap renaming of notes through autotile in locking context

### DIFF
--- a/lib/Service/Note.php
+++ b/lib/Service/Note.php
@@ -179,4 +179,8 @@ class Note {
 			$this->noteUtil->getTagService()->setFavorite($this->getId(), $favorite);
 		}
 	}
+
+	public function getFile(): File {
+		return $this->file;
+	}
 }


### PR DESCRIPTION
Otherwise setting the title of the note will fail when editing through the text editor if files_lock is enabled