### PR TITLE
chore(release): Bump version to 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,7 @@ Types of changes:
 - *Fixed* for any bug fixes.
 - *Security* in case of vulnerabilities. 
 
-## 4.8.0-beta.2
-
-### Fixed
-
-- Use the color-primary-element* variables @szaimen [#1043](https://github.com/nextcloud/notes/pull/1043)
-- fix: setting button spacing @luka-nextcloud [#1048](https://github.com/nextcloud/notes/pull/1048)
-- fix: Wrap renaming of notes through autotile in locking context @juliushaertl [#1047](https://github.com/nextcloud/notes/pull/1047)
-- Dependency updates
-
-## 4.8.0-beta.1 - 2023-05-05
+## 4.8.0
 
 ### Added
 
@@ -30,6 +21,9 @@ Types of changes:
 
 ### Fixed
 
+- Use the color-primary-element* variables @szaimen [#1043](https://github.com/nextcloud/notes/pull/1043)
+- fix: setting button spacing @luka-nextcloud [#1048](https://github.com/nextcloud/notes/pull/1048)
+- fix: Wrap renaming of notes through autotile in locking context @juliushaertl [#1047](https://github.com/nextcloud/notes/pull/1047)
 - Fix help table on dark mode @eckelon [#1000](https://github.com/nextcloud/notes/pull/1000)
 - fix: Proper response for attachment endpoint @juliushaertl [#1031](https://github.com/nextcloud/notes/pull/1031)
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[
 The Notes app is a distraction free notes taking app for [Nextcloud](https://www.nextcloud.com/). It provides categories for better organization and supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [REST API](https://github.com/nextcloud/notes/blob/master/docs/api/README.md) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/nextcloud/notes-android), [iOS](https://github.com/nextcloud/notes-ios) and the [console](https://git.danielmoch.com/nncli/about) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites.
 ]]></description>
-	<version>4.8.0-beta.2</version>
+	<version>4.8.0</version>
 	<licence>agpl</licence>
 	<author>Kristof Hamann</author>
 	<author>Bernhard Posselt</author>

--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
 	"browserslist": [
 		"extends @nextcloud/browserslist-config"
 	],
-	"version": "4.8.0-beta.2"
+	"version": "4.8.0"
 }


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>
