### PR TITLE
ci: Pin php-cs-fixer/shim

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
 		"nextcloud/coding-standard": "^1.0",
 		"squizlabs/php_codesniffer": "^3",
 		"phan/phan": "^5",
+		"php-cs-fixer/shim": "3.20.0",
 		"guzzlehttp/guzzle": "^7",
 		"staabm/annotate-pull-request-from-checkstyle": "^1.1.0"
 	},


### PR DESCRIPTION
Should bring back green CI after the latest **patch** release of php-cs-fixer dropped php 7.4 support and is marked as [experimental](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.21.1) 🙈 