### PR TITLE
fix: Check for the notes app version for editor hint

### DIFF
--- a/lib/Migration/EditorHint.php
+++ b/lib/Migration/EditorHint.php
@@ -46,7 +46,7 @@ class EditorHint implements IRepairStep {
 	}
 
 	public function run(IOutput $output) {
-		$appVersion = $this->config->getAppValue('text', 'installed_version');
+		$appVersion = $this->config->getAppValue('notes', 'installed_version');
 
 		if (!$appVersion || version_compare($appVersion, '4.7.0') !== -1) {
 			return;


### PR DESCRIPTION
Avoid showing the hint for the new editor on every update

fixes https://github.com/nextcloud/notes/issues/1038