### PR TITLE
Fix autotitle and save status

### DIFF
--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -1,6 +1,7 @@
 <template>
 	<NoteRich v-if="isRichMode" :note-id="noteId" />
 	<NotePlain v-else-if="isPlainMode" :note-id="noteId" />
+	<div v-else />
 </template>
 <script>
 import NoteRich from './NoteRich.vue'
@@ -24,10 +25,10 @@ export default {
 
 	computed: {
 		isRichMode() {
-			return window.oc_appswebroots.text && store.state.app.settings.noteMode === 'rich'
+			return window.oc_appswebroots.text && store.state.app?.settings?.noteMode === 'rich'
 		},
 		isPlainMode() {
-			return store.state.app.settings.noteMode !== null && store.state.app.settings.noteMode !== 'rich'
+			return store.state.app?.settings?.noteMode === 'edit' || store.state.app?.settings?.noteMode === 'preview'
 		},
 	},
 }

--- a/src/components/NoteRich.vue
+++ b/src/components/NoteRich.vue
@@ -49,6 +49,7 @@ export default {
 	watch: {
 		$route(to, from) {
 			if (to.name !== from.name || to.params.noteId !== from.params.noteId) {
+				this.onClose(from.params.noteId)
 				this.fetchData()
 			}
 		},
@@ -96,7 +97,7 @@ export default {
 							const title = this.getTitle(markdown)
 							this.shouldAutotitle = this.isNewNote || (title !== '' && title === this.note.title)
 						}
-						this.onEdit({ content: markdown, unsaved: unsaved})
+						this.onEdit({ content: markdown, unsaved })
 					}
 				},
 			}))
@@ -109,6 +110,14 @@ export default {
 			store.commit('updateNote', {
 				...this.note,
 				...noteData,
+			})
+		},
+
+		onClose(noteId) {
+			const note = store.getters.getNote(parseInt(noteId))
+			store.commit('updateNote', {
+				...note,
+				unsaved: false,
 			})
 		},
 


### PR DESCRIPTION
- fix: Only use autotitle if the filename is unchanged 
  - fixes #1071 
  - fixes https://github.com/nextcloud/notes/issues/1029
  - fixes https://github.com/nextcloud/notes/issues/987
- fix: Avoid flaky note mode checks
- fix: Properly indicate save status on switching notes
  - fixes https://github.com/nextcloud/notes/issues/1019
