### PR TITLE
Expose image api for other clients as api v1.4

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -177,7 +177,7 @@ return ['routes' => [
 		'url' => '/api/{apiVersion}/settings',
 		'verb' => 'GET',
 		'requirements' => [
-			'apiVersion' => '(v1)',
+			'apiVersion' => '(v1|v1.4)',
 		],
 	],
 	[
@@ -195,6 +195,24 @@ return ['routes' => [
 		'requirements' => [
 			'apiVersion' => '(v0.2|v1)',
 			'path' => '.+',
+		],
+	],
+	[
+		'name' => 'notes_api#getAttachment',
+		'url' => '/api/{apiVersion}/attachment/{noteid}',
+		'verb' => 'GET',
+		'requirements' => [
+			'apiVersion' => '(v1.4)',
+			'noteid' => '\d+'
+		],
+	],
+	[
+		'name' => 'notes_api#uploadFile',
+		'url' => '/api/{apiVersion}/attachment/{noteid}',
+		'verb' => 'POST',
+		'requirements' => [
+			'apiVersion' => '(v1.4)',
+			'noteid' => '\d+'
 		],
 	],
 ]];

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -5,12 +5,13 @@ In this document, the Notes API major version 1 and all its minor versions are d
 
 ## Minor versions
 
-| API version | Introduced with app version | Remarkable Changes |
-|:-----------:|:----------------------------|:-------------------|
-|  **1.0**    | Notes 3.3 (May 2020)        | Separate title, no auto rename based on content |
-|  **1.1**    | Notes 3.4 (May 2020)        | Filter "Get all notes" by category |
-|  **1.2**    | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
-|  **1.3**    | Notes 4.5 (August 2022)     | Allow custom file suffixes |
+| API version | Introduced with app version | Remarkable Changes                                 |
+|:-----------:|:----------------------------|:---------------------------------------------------|
+|   **1.0**   | Notes 3.3 (May 2020)        | Separate title, no auto rename based on content    |
+|   **1.1**   | Notes 3.4 (May 2020)        | Filter "Get all notes" by category                 |
+|   **1.2**   | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
+|   **1.3**   | Notes 4.5 (August 2022)     | Allow custom file suffixes                         |
+|   **1.4**   | Notes 4.9 (November 2023)   | Add external image api                             |
 
 
 
@@ -132,7 +133,7 @@ Note not found.
 <details><summary>Details</summary>
 
 #### Request parameters
-- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example: 
+- **Body**: some or all "read/write" attributes (see section [Note attributes](#note-attributes)), example:
 ```js
 {
     "title": "New note",
@@ -273,6 +274,52 @@ No valid authentication credentials supplied.
 </details>
 
 
+
+### Get attachment (`GET /attachment/{id}`)
+<details><summary>Details</summary>
+
+*(since API v1.4)*
+
+#### Request parameters
+| Parameter | Type                    | Description                        |
+|:----------|:------------------------|:-----------------------------------|
+| `path`    | string, required (path) | Path or name of the image to load. |
+
+#### Response
+##### 200 OK
+- **Body**: Image or File
+
+##### 400 Bad Request
+Endpoint not supported by installed notes app version (requires API version 1.4).
+
+##### 401 Unauthorized
+No valid authentication credentials supplied.
+</details>
+
+
+### Put attachment (`POST /attachment/{id}`)
+<details><summary>Details</summary>
+
+*(since API v1.4)*
+
+#### Request parameters
+None.
+
+#### Response
+##### 200 OK
+- **Body**: Filename in json encoded:
+```js
+{
+    "filename": "image.jpg"
+}
+```
+
+##### 400 Bad Request
+Endpoint not supported by installed notes app version (requires API version 1.4).
+
+##### 401 Unauthorized
+No valid authentication credentials supplied.
+</details>
 
 ## Preventing lost updates and conflict solution
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,7 +12,7 @@ use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'notes';
-	public static array $API_VERSIONS = [ '0.2', '1.3' ];
+	public static array $API_VERSIONS = [ '0.2', '1.3', '1.4' ];
 
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);


### PR DESCRIPTION
This allows external apps to resolve images.

Could someone please test the api-endpoints? They have been very unreliable for me, though i dont know why. The actual code behind the endpoint works, and is identical to the internal api.