### PR TITLE
Fix dashboard icons

### DIFF
--- a/lib/AppInfo/DashboardWidget.php
+++ b/lib/AppInfo/DashboardWidget.php
@@ -92,11 +92,9 @@ class DashboardWidget implements IWidget, IButtonWidget, IAPIWidget, IIconWidget
 			} catch (\Throwable $e) {
 			}
 			$link = $this->url->linkToRouteAbsolute('notes.page.indexnote', ['id' => $note->getId()]);
-			$icon = $this->url->getAbsoluteURL(
-				$note->getFavorite()
-					? $this->url->getAbsoluteURL($this->url->imagePath('core', 'actions/starred.svg'))
-					: $this->getIconUrl()
-			);
+			$icon = $note->getFavorite()
+				? $this->url->getAbsoluteURL($this->url->imagePath('core', 'actions/starred.svg'))
+				: $this->getIconUrl();
 			return new WidgetItem($note->getTitle(), $excerpt, $link, $icon, (string)$note->getModified());
 		}, $notes);
 	}


### PR DESCRIPTION
Calling `getAbsoluteURL` twice leads to URLs like `http://localhost/http://localhost/apps/notes/img/notes-dark.svg`.
I think this never got noticed because the web frontend doesn't directly use the items but the custom Javascript rendering instead. Maybe that is broken as well since no icon is displayed there?
![image](https://github.com/nextcloud/notes/assets/26026535/058e0dc3-ed14-4d31-b8d8-be48d8ada3f9)
