### PR TITLE
Avoid throwing on other share types than user

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -37,7 +37,11 @@ class Application extends App implements IBootstrap {
 			);
 		} else {
 			// FIXME: Remove once Nextcloud 28 is the minimum supported version
-			\OCP\Server::get(IEventDispatcher::class)->addListener('OCP\Share::preShare', function (GenericEvent $event) {
+			\OCP\Server::get(IEventDispatcher::class)->addListener('OCP\Share::preShare', function ($event) {
+				if (!$event instanceof GenericEvent) {
+					return;
+				}
+
 				/** @var IShare $share */
 				$share = $event->getSubject();
 

--- a/lib/AppInfo/BeforeShareCreatedListener.php
+++ b/lib/AppInfo/BeforeShareCreatedListener.php
@@ -11,14 +11,16 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Files\File;
 use OCP\Share\Events\BeforeShareCreatedEvent;
 use OCP\Share\IShare;
+use Psr\Log\LoggerInterface;
 
 class BeforeShareCreatedListener implements IEventListener {
 	private SettingsService $settings;
 	private NoteUtil $noteUtil;
 
-	public function __construct(SettingsService $settings, NoteUtil $noteUtil) {
+	public function __construct(SettingsService $settings, NoteUtil $noteUtil, LoggerInterface $logger) {
 		$this->settings = $settings;
 		$this->noteUtil = $noteUtil;
+		$this->logger = $logger;
 	}
 
 	public function handle(Event $event): void {
@@ -36,22 +38,28 @@ class BeforeShareCreatedListener implements IEventListener {
 			return;
 		}
 
-		$fileSourcePath = $share->getNode()->getPath();
-		$itemTarget = $share->getTarget();
-		$uidOwner = $share->getSharedBy();
-		$ownerPath = $this->noteUtil->getRoot()->getUserFolder($uidOwner)->getPath();
-		$ownerNotesPath = $ownerPath . '/' . $this->settings->get($uidOwner, 'notesPath');
+		try {
+			$fileSourcePath = $share->getNode()->getPath();
+			$itemTarget = $share->getTarget();
+			$uidOwner = $share->getSharedBy();
+			$ownerPath = $this->noteUtil->getRoot()->getUserFolder($uidOwner)->getPath();
+			$ownerNotesPath = $ownerPath . '/' . $this->settings->get($uidOwner, 'notesPath');
 
-		$receiver = $share->getSharedWith();
-		$receiverPath = $this->noteUtil->getRoot()->getUserFolder($receiver)->getPath();
-		$receiverNotesInternalPath = $this->settings->get($receiver, 'notesPath');
-		$receiverNotesPath = $receiverPath . '/' . $receiverNotesInternalPath;
-		$this->noteUtil->getOrCreateFolder($receiverNotesPath);
+			$receiver = $share->getSharedWith();
+			$receiverPath = $this->noteUtil->getRoot()->getUserFolder($receiver)->getPath();
+			$receiverNotesInternalPath = $this->settings->get($receiver, 'notesPath');
+			$receiverNotesPath = $receiverPath . '/' . $receiverNotesInternalPath;
+			$this->noteUtil->getOrCreateFolder($receiverNotesPath);
 
-		if ($itemType !== 'file' || strpos($fileSourcePath, $ownerNotesPath) !== 0) {
-			return;
+			if ($itemType !== 'file' || strpos($fileSourcePath, $ownerNotesPath) !== 0) {
+				return;
+			}
+
+			$share->setTarget('/' . $receiverNotesInternalPath . $itemTarget);
+		} catch (\Throwable $e) {
+			$this->logger->error('Failed to overwrite share target for notes', [
+				'exception' => $e,
+			]);
 		}
-
-		$share->setTarget('/' . $receiverNotesInternalPath . $itemTarget);
 	}
 }

--- a/lib/AppInfo/BeforeShareCreatedListener.php
+++ b/lib/AppInfo/BeforeShareCreatedListener.php
@@ -31,6 +31,11 @@ class BeforeShareCreatedListener implements IEventListener {
 
 	public function overwriteShareTarget(IShare $share): void {
 		$itemType = $share->getNode() instanceof File ? 'file' : 'folder';
+
+		if ($share->getShareType() !== IShare::TYPE_USER) {
+			return;
+		}
+
 		$fileSourcePath = $share->getNode()->getPath();
 		$itemTarget = $share->getTarget();
 		$uidOwner = $share->getSharedBy();


### PR DESCRIPTION
- fix: Only apply share target overwrite on user shares
- fix: Catch any errors when overwriting share target and log it instead of failing
- fix: Avoid failing due to different event types across Nextcloud versions (fix #1152)
