### PR TITLE
fix: Resolve file list dependency of the sidebar on Nextcloud <= 27

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,10 @@ import store from './store.js'
 
 Vue.mixin({ methods: { t, n } })
 
+// Make sure that the filesClient is available in the global scope used by the sidebar
+// FIXME: Can be dropped once Nextcloud 28 is the minimum supported version
+Object.assign(window.OCA.Files, { App: { fileList: { filesClient: OC.Files.getClient() } } }, window.OCA.Files)
+
 export default new Vue({
 	el: '#content',
 	store,


### PR DESCRIPTION
Fix #1173 

The dashboard apparently has this as well for 27 (ref https://github.com/nextcloud/server/commit/d9dcd59ae1ea258f57fe4a92eaea6f4ba63f54c8), otherwise the sidebar on 27 will try to access the client from there which does not exist.