### PR TITLE
fix: Avoid using constant that is not available on 25

### DIFF
--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -229,7 +229,8 @@ class NoteUtil {
 			IShare::TYPE_EMAIL,
 			IShare::TYPE_ROOM,
 			IShare::TYPE_DECK,
-			IShare::TYPE_SCIENCEMESH,
+			// FIXME: Move to constant once Nextcloud 26 is the minimum supported version
+			15, // IShare::TYPE_SCIENCEMESH,
 		];
 		$shareTypes = [];
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/notes/issues/1177 for stable25