### PR TITLE
feat: extract preview and fullscreen actions from three-dot-menu

### DIFF
--- a/lib/Controller/Helper.php
+++ b/lib/Controller/Helper.php
@@ -55,7 +55,7 @@ class Helper {
 		return $note;
 	}
 
-	public function getNoteData(Note $note, array $exclude = [], Meta $meta = null) : array {
+	public function getNoteData(Note $note, array $exclude = [], ?Meta $meta = null) : array {
 		if ($meta === null) {
 			$meta = $this->metaService->update($this->getUID(), $note);
 		}
@@ -67,9 +67,9 @@ class Helper {
 	public function getNotesAndCategories(
 		int $pruneBefore,
 		array $exclude,
-		string $category = null,
+		?string $category = null,
 		int $chunkSize = 0,
-		string $chunkCursorStr = null
+		?string $chunkCursorStr = null
 	) : array {
 		$userId = $this->getUID();
 		$chunkCursor = $chunkCursorStr ? ChunkCursor::fromString($chunkCursorStr) : null;

--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -46,7 +46,7 @@ class NotesApiController extends ApiController {
 		string $exclude = '',
 		int $pruneBefore = 0,
 		int $chunkSize = 0,
-		string $chunkCursor = null
+		?string $chunkCursor = null
 	) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use (
 			$category,

--- a/lib/Service/MetaService.php
+++ b/lib/Service/MetaService.php
@@ -131,7 +131,7 @@ class MetaService {
 		return $result;
 	}
 
-	private function createMeta(string $userId, Note $note, callable $onError = null) : Meta {
+	private function createMeta(string $userId, Note $note, ?callable $onError = null) : Meta {
 		$meta = new Meta();
 		$meta->setUserId($userId);
 		$meta->setFileId($note->getId());

--- a/src/components/EditorEasyMDE.vue
+++ b/src/components/EditorEasyMDE.vue
@@ -370,7 +370,7 @@ export default {
 
 .upload-button {
 	position: fixed;
-	inset-inline-end: 64px;
+	inset-inline-end: 112px;
 	z-index: 10;
 	height: 40px;
 	margin-inline-end: 5px;

--- a/src/components/NotePlain.vue
+++ b/src/components/NotePlain.vue
@@ -9,7 +9,9 @@
 				<div class="conflict-modal">
 					<div class="conflict-header">
 						<SyncAlertIcon slot="icon" :size="30" fill-color="var(--color-error)" />
-						{{ t('notes', 'The note has been changed in another session. Please choose which version should be saved.') }}
+						{{
+							t('notes', 'The note has been changed in another session. Please choose which version should be saved.')
+						}}
 					</div>
 					<div class="conflict-solutions">
 						<ConflictSolution
@@ -46,20 +48,24 @@
 				/>
 			</div>
 			<span class="action-buttons">
-				<NcActions :open.sync="actionsOpen" container=".action-buttons" menu-align="right">
-					<NcActionButton
-						v-tooltip.left="t('notes', 'CTRL + /')"
-						@click="onTogglePreview"
-					>
-						<EditIcon v-if="preview" slot="icon" :size="20" />
-						<EyeIcon v-else slot="icon" :size="20" />
+				<NcActions menu-align="right" container=".action-buttons">
+					<NcActionButton v-tooltip.left="t('notes', 'CTRL + /')" @click="onTogglePreview">
+						<template #icon>
+							<EditIcon v-if="preview" :size="20" />
+							<EyeIcon v-else :size="20" />
+						</template>
 						{{ preview ? t('notes', 'Edit') : t('notes', 'Preview') }}
 					</NcActionButton>
+				</NcActions>
+
+				<NcActions :open.sync="actionsOpen" container=".action-buttons" menu-align="right">
 					<NcActionButton
 						:class="{ active: fullscreen }"
 						@click="onToggleDistractionFree"
 					>
-						<FullscreenIcon slot="icon" :size="20" />
+						<template #icon>
+							<FullscreenIcon :size="20" />
+						</template>
 						{{ fullscreen ? t('notes', 'Exit full screen') : t('notes', 'Full screen') }}
 					</NcActionButton>
 				</NcActions>
@@ -105,7 +111,14 @@ import NoEditIcon from 'vue-material-design-icons/PencilOff.vue'
 import SyncAlertIcon from 'vue-material-design-icons/SyncAlert.vue'
 
 import { config } from '../config.js'
-import { fetchNote, refreshNote, saveNoteManually, queueCommand, conflictSolutionLocal, conflictSolutionRemote } from '../NotesService.js'
+import {
+	fetchNote,
+	refreshNote,
+	saveNoteManually,
+	queueCommand,
+	conflictSolutionLocal,
+	conflictSolutionRemote,
+} from '../NotesService.js'
 import { routeIsNewNote } from '../Util.js'
 import TheEditor from './EditorEasyMDE.vue'
 import ThePreview from './EditorMarkdownIt.vue'
@@ -437,6 +450,7 @@ export default {
 	.note-editor {
 		margin: 0 auto;
 	}
+
 	.note-container {
 		padding-inline-end: 250px;
 		transition-duration: var(--animation-quick);
@@ -468,7 +482,7 @@ export default {
 	position: fixed;
 	top: 50px;
 	inset-inline-end: 20px;
-	width: 44px;
+	width: 94px;
 	margin-top: 1em;
 	z-index: 2000;
 }

--- a/tests/api/APIv1Test.php
+++ b/tests/api/APIv1Test.php
@@ -74,7 +74,7 @@ class APIv1Test extends CommonAPITest {
 		array $indexedRefNotes,
 		int $chunkSize,
 		string $messagePrefix,
-		string $chunkCursor = null,
+		?string $chunkCursor = null,
 		array $collectedNotes = []
 	) : array {
 		$requestCount = 0;

--- a/tests/api/AbstractAPITest.php
+++ b/tests/api/AbstractAPITest.php
@@ -69,7 +69,7 @@ abstract class AbstractAPITest extends TestCase {
 		string $message,
 		?string $param = '',
 		array $expectExclude = [],
-		array $expectedFullNotes = null
+		?array $expectedFullNotes = null
 	) : void {
 		$messagePrefix = 'Check reference notes '.$message;
 		$response = $this->http->request('GET', 'notes' . $param);
@@ -83,7 +83,7 @@ abstract class AbstractAPITest extends TestCase {
 		array $notes,
 		string $messagePrefix,
 		array $expectExclude = [],
-		array $expectedFullNotes = null
+		?array $expectedFullNotes = null
 	) : void {
 		$this->assertIsArray($notes, $messagePrefix);
 		$notesMap = $this->getNotesIdMap($notes, $messagePrefix);
@@ -204,7 +204,7 @@ abstract class AbstractAPITest extends TestCase {
 		\stdClass &$note,
 		\stdClass $request,
 		\stdClass $expected,
-		string $etag = null,
+		?string $etag = null,
 		int $statusExp = 200
 	) {
 		$requestOptions = [ 'json' => $request ];


### PR DESCRIPTION
This PR explodes the preview/edit-toggle and the full-screen button from the three-dots menu as suggested in #366.
In the discussion it sounded like it would be an idea to only extract the preview/edit-toggle, but as only the fullscreen was left in the menu, that didn't seem reasonable.

 Two screenshots what the result looks like:
<img width="253" alt="Screenshot 2024-03-17 at 19 25 22" src="https://github.com/nextcloud/notes/assets/300609/35ecf0cd-d172-4feb-a7ab-ce3c1d9c3cb6">
<img width="246" alt="Screenshot 2024-03-17 at 19 25 13" src="https://github.com/nextcloud/notes/assets/300609/d6efae0b-e6e0-4494-9e4c-db2dbef1b442">

Open for any feedback, the discussion in #366 has been stale for while already.