### PR TITLE
fix: Shared folder check

### DIFF
--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -168,14 +168,15 @@ class NoteUtil {
 			$folder = $this->root->newFolder($path);
 		}
 
+		if (!($folder instanceof Folder)) {
+			throw new NotesFolderException($path.' is not a folder');
+		}
+
 		if ($folder->isShared()) {
 			$folderName = $this->root->getNonExistingName($path);
 			$folder = $this->root->newFolder($folderName);
 		}
 
-		if (!($folder instanceof Folder)) {
-			throw new NotesFolderException($path.' is not a folder');
-		}
 		return $folder;
 	}
 


### PR DESCRIPTION
Fixes `Call to a member function isShared() on null in file '/usr/src/nextcloud/apps/notes/lib/Service/NoteUtil.php' line 171` introduced by https://github.com/nextcloud/notes/pull/1260.

This is triggered when the user has no notes folder yet and opens the dashboard (at least that was how I triggered it).