### PR TITLE
Fix "TypeError: t is undefined"

### DIFF
--- a/src/components/NoteRich.vue
+++ b/src/components/NoteRich.vue
@@ -52,7 +52,7 @@ export default {
 		},
 	},
 
-	created() {
+	mounted() {
 		this.fetchData()
 		subscribe('files:file:updated', this.fileUpdated)
 		subscribe('files_versions:restore:requested', this.onFileRestoreRequested)


### PR DESCRIPTION
vue "created" does not guaranteed that all refs are filled. Sometime $refs.editor is undefined. Also an extra tick like in line 84 does not help. 

created() is great for calling APIs, while mounted() is great for doing anything after the DOM elements have completely loaded.

using "mounted" instead of "created" fixes this issues

the bug itself is documented here

https://github.com/nextcloud/notes/issues/1259