### PR TITLE
fix: escape html string @ inline code

### DIFF
--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -148,10 +148,19 @@ export default {
 			}
 		},
 
+		escapeHTML(string) {
+			// Replace anything is not ASCII Digit, Latin Alphabet Uppercase & lowercase
+			// https://en.wikipedia.org/wiki/List_of_Unicode_characters
+			return string.replace(/[^\u0030-\u0039\u0041-\u005A\u0061-\u007A]/g, function(char) {
+				return `&#${char.charCodeAt()}`
+			})
+		},
+
 		setInlineCodeRule() {
+			const editorInstance = this
 			this.md.renderer.rules.code_inline = function(tokens, idx, options, env, self) {
 				const token = tokens[idx]
-				return '<code class="inline-code">' + token.content + '</code>'
+				return '<code class="inline-code">' + editorInstance.escapeHTML(token.content) + '</code>'
 			}
 		},
 	},


### PR DESCRIPTION
Was unable to render
```
`<C-a>`
```
![210424_08-57-25-PM_hyZz5KRGQz](https://github.com/nextcloud/notes/assets/46382253/3d56a95b-eef4-408e-a40d-50dcb709646d)
