### PR TITLE
allow using shared notes folder

### DIFF
--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -172,11 +172,6 @@ class NoteUtil {
 			throw new NotesFolderException($path.' is not a folder');
 		}
 
-		if ($folder->isShared()) {
-			$folderName = $this->root->getNonExistingName($path);
-			$folder = $this->root->newFolder($folderName);
-		}
-
 		return $folder;
 	}
 


### PR DESCRIPTION
Enables the use of a shared folder as a notes folder. Reverts PR #1260 as it is not clear what the problem was and using a shared notes folder is a feature that many users use: #1266