### PR TITLE
fix/shared notes

### DIFF
--- a/lib/AppInfo/BeforeShareCreatedListener.php
+++ b/lib/AppInfo/BeforeShareCreatedListener.php
@@ -49,8 +49,7 @@ class BeforeShareCreatedListener implements IEventListener {
 			$receiver = $share->getSharedWith();
 			$receiverPath = $this->noteUtil->getRoot()->getUserFolder($receiver)->getPath();
 			$receiverNotesInternalPath = $this->settings->get($receiver, 'notesPath');
-			$receiverNotesPath = $receiverPath . '/' . $receiverNotesInternalPath;
-			$this->noteUtil->getOrCreateFolder($receiverNotesPath);
+			$this->noteUtil->getOrCreateNotesFolder($receiver);
 
 			if ($itemType !== 'file' || strpos($fileSourcePath, $ownerNotesPath) !== 0) {
 				return;

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -21,6 +21,7 @@ class NoteUtil {
 	private TagService $tagService;
 	private IManager $shareManager;
 	private IUserSession $userSession;
+	private SettingsService $settingsService;
 
 	public function __construct(
 		Util $util,
@@ -28,7 +29,8 @@ class NoteUtil {
 		IDBConnection $db,
 		TagService $tagService,
 		IManager $shareManager,
-		IUserSession $userSession
+		IUserSession $userSession,
+		SettingsService $settingsService
 	) {
 		$this->util = $util;
 		$this->root = $root;
@@ -36,6 +38,7 @@ class NoteUtil {
 		$this->tagService = $tagService;
 		$this->shareManager = $shareManager;
 		$this->userSession = $userSession;
+		$this->settingsService = $settingsService;
 	}
 
 	public function getRoot() : IRootFolder {
@@ -172,9 +175,36 @@ class NoteUtil {
 			throw new NotesFolderException($path.' is not a folder');
 		}
 
-		if ($folder->isShared()) {
-			$folderName = $this->root->getNonExistingName($path);
-			$folder = $this->root->newFolder($folderName);
+		return $folder;
+	}
+
+	public function getOrCreateNotesFolder(string $userId, bool $create = true) : Folder {
+		$userFolder = $this->getRoot()->getUserFolder($userId);
+		$notesPath = $this->settingsService->get($userId, 'notesPath');
+		$allowShared = $notesPath !== $this->settingsService->getDefaultNotesPath($userId);
+
+		$folder = null;
+		$updateNotesPath = false;
+		if ($userFolder->nodeExists($notesPath)) {
+			$folder = $userFolder->get($notesPath);
+			if (!$allowShared && $folder->isShared()) {
+				$notesPath = $userFolder->getNonExistingName($notesPath);
+				$folder = $userFolder->newFolder($notesPath);
+				$updateNotesPath = true;
+			}
+		} elseif ($create) {
+			$folder = $userFolder->newFolder($notesPath);
+			$updateNotesPath = true;
+		}
+
+		if (!($folder instanceof Folder)) {
+			throw new NotesFolderException($notesPath . ' is not a folder');
+		}
+
+		if ($updateNotesPath) {
+			$this->settingsService->set($userId, [
+				'notesPath' => $notesPath,
+			]);
 		}
 
 		return $folder;

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -204,7 +204,7 @@ class NoteUtil {
 		if ($updateNotesPath) {
 			$this->settingsService->set($userId, [
 				'notesPath' => $notesPath,
-			]);
+			], true);
 		}
 
 		return $folder;

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -149,20 +149,8 @@ class NotesService {
 		return $this->noteUtil->getSafeTitle($content);
 	}
 
-
-
-
-
-
-	/**
-	 * @param string $userId the user id
-	 * @return Folder
-	 */
 	private function getNotesFolder(string $userId, bool $create = true) : Folder {
-		$userPath = $this->noteUtil->getRoot()->getUserFolder($userId)->getPath();
-		$path = $userPath . '/' . $this->settings->get($userId, 'notesPath');
-		$folder = $this->noteUtil->getOrCreateFolder($path, $create);
-		return $folder;
+		return $this->noteUtil->getOrCreateNotesFolder($userId, $create);
 	}
 
 	/**

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -81,7 +81,7 @@ class SettingsService {
 		];
 	}
 
-	private function getDefaultNotesPath(string $uid) : string {
+	public function getDefaultNotesPath(string $uid) : string {
 		$defaultFolder = $this->config->getAppValue(Application::APP_ID, 'defaultFolder', 'Notes');
 		$defaultExists = $this->root->getUserFolder($uid)->nodeExists($defaultFolder);
 		if ($defaultExists) {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -107,9 +107,10 @@ class SettingsService {
 			if ($value !== null && array_key_exists($name, $this->attrs)) {
 				$settings[$name] = $value = $this->attrs[$name]['validate']($value);
 			}
+			$default = is_callable($this->attrs[$name]['default']) ? $this->attrs[$name]['default']($uid) : $this->attrs[$name]['default'];
 			if (!array_key_exists($name, $this->attrs)
 				|| $value === null
-				|| $value === $this->attrs[$name]['default']
+				|| $value === $default
 			) {
 				unset($settings[$name]);
 			}

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -94,7 +94,7 @@ class SettingsService {
 	/**
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function set(string $uid, array $settings) : void {
+	public function set(string $uid, array $settings, bool $writeDefaults = false) : void {
 		// load existing values for missing attributes
 		$oldSettings = $this->getSettingsFromDB($uid);
 		foreach ($oldSettings as $name => $value) {
@@ -108,10 +108,10 @@ class SettingsService {
 				$settings[$name] = $value = $this->attrs[$name]['validate']($value);
 			}
 			$default = is_callable($this->attrs[$name]['default']) ? $this->attrs[$name]['default']($uid) : $this->attrs[$name]['default'];
-			if (!array_key_exists($name, $this->attrs)
+			if (!$writeDefaults && (!array_key_exists($name, $this->attrs)
 				|| $value === null
 				|| $value === $default
-			) {
+			)) {
 				unset($settings[$name]);
 			}
 		}


### PR DESCRIPTION
The current backend logic to get or create a notes folder is not ideal as we cannot easily determine if a folder exists because a user has created and set is as notes folder before or if it was manually picked as a notes folder.

To avoid issues with the wrong incoming shared folder being taken as notes folder automatically this PR refactors the logic so that we now no longer store the notes folder in the config with the default value, until it was actually created. That way we know as soon as the config value is set, we no longer need to check for incoming shares on the folder. 

Fix https://github.com/nextcloud/notes/issues/1266