### PR TITLE
chore: Bump minimum supported versions to 28

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<description><![CDATA[
 The Notes app is a distraction free notes taking app for [Nextcloud](https://www.nextcloud.com/). It provides categories for better organization and supports formatting using [Markdown](https://en.wikipedia.org/wiki/Markdown) syntax. Notes are saved as files in your Nextcloud, so you can view and edit them with every Nextcloud client. Furthermore, a separate [REST API](https://github.com/nextcloud/notes/blob/master/docs/api/README.md) allows for an easy integration into third-party apps (currently, there are notes apps for [Android](https://github.com/nextcloud/notes-android), [iOS](https://github.com/nextcloud/notes-ios) and the [console](https://git.danielmoch.com/nncli/about) which allow convenient access to your Nextcloud notes). Further features include marking notes as favorites.
 ]]></description>
-	<version>4.10.0</version>
+	<version>4.11.0-dev.0</version>
 	<licence>agpl</licence>
 	<author>Kristof Hamann</author>
 	<author>Bernhard Posselt</author>
@@ -21,8 +21,8 @@ The Notes app is a distraction free notes taking app for [Nextcloud](https://www
 	<repository type="git">https://github.com/nextcloud/notes.git</repository>
 	<screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
 	<dependencies>
-		<php min-version="7.4" max-version="8.3"/>
-		<nextcloud min-version="25" max-version="30"/>
+		<php min-version="8.0" max-version="8.3"/>
+		<nextcloud min-version="28" max-version="30"/>
 	</dependencies>
 	<repair-steps>
 		<post-migration>


### PR DESCRIPTION
Let's cut off some old versions since the vue components are 28+ from the current stable release