### PR TITLE
fix: AppSettings using bad notes-path for file picker

### DIFF
--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -162,7 +162,7 @@ export default {
 				true, // modal
 				FilePickerType.Choose, // type
 				true, // directories
-				event.target.value === '' ? '/' : event.target.value, // path
+				event.target.value === '' ? '/' : `/${event.target.value}`, // path
 			)
 			filePicker.pick().then((file) => {
 				const client = OC.Files.getClient()


### PR DESCRIPTION
Fixing the bug of the filepicker discovered after the merge of https://github.com/nextcloud/notes/pull/1341 to fix the issue specified by https://github.com/nextcloud/notes/issues/1186#issuecomment-2275245032

Tested the fix on Nextcloud(AIO): 29.0.2.2 with Firefox128.0.3 (64-bit).