### PR TITLE
Fix: Correct path in settings to load the actual path

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@
  - Camila Ayres <smayres@gmail.com>
  - Camila San <hello@camila.codes>
  - Christian Weiske <cweiske@cweiske.de>
+ - Christian Wolf <github@christianwolf.email>
  - Christoph Wurst <ChristophWurst@users.noreply.github.com>
  - Dan Muckerman <danielmuckerman@me.com>
  - Daniel <mail@danielkesselberg.de>

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -161,7 +161,7 @@ export default {
 		async onChangeNotePath(event) {
 			const filePicker = getFilePickerBuilder(t('notes', 'Pick a notes folder'))
 				.allowDirectories(true)
-				.startAt(event.target.value === '' ? '/' : event.target.value)
+				.startAt(event.target.value === '' ? '/' : `/${event.target.value}`)
 				.addButton({
 					label: t('notes', 'Set notes folder'),
 					callback: (nodes) => {


### PR DESCRIPTION
Closes #1375 

This is just a quick fix for the bug in order to test further. I am not sure if this is the right way to do it as this might as well be an issue with the underlying `@nextcloud/dialogs` library, I am not sure about this, though.