### PR TITLE
fix: Adjust note item size to be one line

### DIFF
--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -8,6 +8,7 @@
 		:name="title"
 		:active="isSelected"
 		:to="{ name: 'note', params: { noteId: note.id.toString() } }"
+		one-line
 		@update:menuOpen="onMenuChange"
 		@click="onNoteSelected(note.id)"
 	>


### PR DESCRIPTION
Otherwise lines are too large with the new more compact design

| Before | After |
|---|---|
| <img width="447" alt="Screenshot 2024-10-10 at 16 52 23" src="https://github.com/user-attachments/assets/c28a206a-5f8d-4a17-a9a5-685afd72e631"> | <img width="434" alt="Screenshot 2024-10-10 at 16 52 32" src="https://github.com/user-attachments/assets/93ac4f0d-fc39-45b7-b75c-d17e4d1fc04c"> |


Fixes #1383