### PR TITLE
Fix note caption colour for custom themes

### DIFF
--- a/src/components/NotesCaption.vue
+++ b/src/components/NotesCaption.vue
@@ -28,7 +28,6 @@ export default {
 <style scoped>
 	.name {
 		font-weight: bold;
-		color: var(--color-primary-element);
 		font-size: var(--default-font-size);
 		line-height: var(--default-clickable-area);
 		white-space: nowrap;


### PR DESCRIPTION
Custom themes may use colours that do not contrast well with the background for their primary element colour, e.g. [my theme](https://codeberg.org/Loowiz/nextcloud-possums-theme)

Removing the line here means the default text colour is used, which I think should be in use here anyway?