### PR TITLE
Revert "add notes path to capabilities"

### DIFF
--- a/lib/AppInfo/Capabilities.php
+++ b/lib/AppInfo/Capabilities.php
@@ -9,16 +9,14 @@ declare(strict_types=1);
 
 namespace OCA\Notes\AppInfo;
 
-use OCA\Notes\Service\NoteUtil;
 use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 
 class Capabilities implements ICapability {
-	public function __construct(
-		private IAppManager $appManager,
-		private NoteUtil $noteUtil,
-		private ?string $userId,
-	) {
+	private IAppManager $appManager;
+
+	public function __construct(IAppManager $appManager) {
+		$this->appManager = $appManager;
 	}
 
 	public function getCapabilities(): array {
@@ -26,7 +24,6 @@ class Capabilities implements ICapability {
 			Application::APP_ID => [
 				'api_version' => Application::$API_VERSIONS,
 				'version' => $this->appManager->getAppVersion(Application::APP_ID),
-				'notes_path' => $this->userId !== null && $this->userId !== ' ' ? $this->noteUtil->getNotesFolderUserPath($this->userId) : null,
 			],
 		];
 	}

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -183,13 +183,6 @@ class NoteUtil {
 		return $folder;
 	}
 
-	public function getNotesFolderUserPath(string $userId): ?string {
-		/** @psalm-suppress MissingDependency */
-		$userFolder = $this->getRoot()->getUserFolder($userId);
-		$nodesFolder = $this->getOrCreateNotesFolder($userId, false);
-		return $userFolder->getRelativePath($nodesFolder->getPath());
-	}
-
 	public function getOrCreateNotesFolder(string $userId, bool $create = true) : Folder {
 		$userFolder = $this->getRoot()->getUserFolder($userId);
 		$notesPath = $this->settingsService->get($userId, 'notesPath');


### PR DESCRIPTION
Reverts nextcloud/notes#1468

I tried to test it and get the error message:
```
Internal Server Error
The server was unable to complete your request.

If this happens again, please send the technical details below to the server administrator.

More details can be found in the server log.

Technical details
Remote Address: 192.168.21.4
Request ID: 1b5EZixWS2bZK7VIVCVm
Type: OCA\Notes\Service\NotesFolderException
Code: 0
Message: Notes is not a folder
File: /var/www/html/apps/notes/lib/Service/NoteUtil.php
Line: 213

Trace
#0 /var/www/html/apps/notes/lib/Service/NoteUtil.php(189): OCA\Notes\Service\NoteUtil->getOrCreateNotesFolder('admin', false)
#1 /var/www/html/apps/notes/lib/AppInfo/Capabilities.php(29): OCA\Notes\Service\NoteUtil->getNotesFolderUserPath('admin')
#2 /var/www/html/lib/private/CapabilitiesManager.php(61): OCA\Notes\AppInfo\Capabilities->getCapabilities()
#3 /var/www/html/lib/private/Template/JSConfigHelper.php(137): OC\CapabilitiesManager->getCapabilities(false, true)
#4 /var/www/html/lib/private/TemplateLayout.php(239): OC\Template\JSConfigHelper->getConfig()
#5 /var/www/html/lib/private/legacy/OC_Template.php(120): OC\TemplateLayout->__construct('user', 'dashboard')
#6 /var/www/html/lib/public/AppFramework/Http/TemplateResponse.php(189): OC_Template->fetchPage(Array)
#7 /var/www/html/lib/private/AppFramework/Http/Dispatcher.php(159): OCP\AppFramework\Http\TemplateResponse->render()
#8 /var/www/html/lib/private/AppFramework/App.php(161): OC\AppFramework\Http\Dispatcher->dispatch(Object(OCA\Dashboard\Controller\DashboardController), 'index')
#9 /var/www/html/lib/private/Route/Router.php(306): OC\AppFramework\App::main('OCA\\Dashboard\\C...', 'index', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#10 /var/www/html/lib/base.php(1018): OC\Route\Router->match('/apps/dashboard...')
#11 /var/www/html/index.php(24): OC::handleRequest()
#12 {main}
```

Not sure if we need to revert or can quickly fix atm