### PR TITLE
fix: Use info instead of warning to avoid filling logs

### DIFF
--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -189,7 +189,7 @@ class NoteUtil {
 		try {
 			$nodesFolder = $this->getOrCreateNotesFolder($userId, false);
 		} catch (NotesFolderException $e) {
-			$this->util->logger->info("Failed to get notes folder for user $userId: " . $e->getMessage());
+			$this->util->logger->debug("Failed to get notes folder for user $userId: " . $e->getMessage());
 			return null;
 		}
 		return $userFolder->getRelativePath($nodesFolder->getPath());


### PR DESCRIPTION
fixes https://github.com/nextcloud/notes/issues/1526