### PR TITLE
Fix slow capabilities

### DIFF
--- a/lib/AppInfo/Capabilities.php
+++ b/lib/AppInfo/Capabilities.php
@@ -26,7 +26,7 @@ class Capabilities implements ICapability {
 			Application::APP_ID => [
 				'api_version' => Application::$API_VERSIONS,
 				'version' => $this->appManager->getAppVersion(Application::APP_ID),
-				'notes_path' => $this->userId !== null && $this->userId !== ' ' ? $this->noteUtil->getNotesFolderUserPath($this->userId) : null,
+				'notes_path' => $this->userId !== null && $this->userId !== ' ' ? $this->noteUtil->getNotesFolderUserPath($this->userId, true) : null,
 			],
 		];
 	}

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -183,9 +183,9 @@ class NoteUtil {
 		return $folder;
 	}
 
-	public function getNotesFolderUserPath(string $userId): ?string {
+	public function getNotesFolderUserPath(string $userId, bool $saveInitial = false): ?string {
 		try {
-			$notesFolder = $this->settingsService->get($userId, 'notesPath');
+			$notesFolder = $this->settingsService->get($userId, 'notesPath', $saveInitial);
 			return $notesFolder;
 		} catch (NotesFolderException $e) {
 			$this->util->logger->debug("Failed to get notes folder for user $userId: " . $e->getMessage());

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -184,15 +184,13 @@ class NoteUtil {
 	}
 
 	public function getNotesFolderUserPath(string $userId): ?string {
-		/** @psalm-suppress MissingDependency */
-		$userFolder = $this->getRoot()->getUserFolder($userId);
 		try {
-			$nodesFolder = $this->getOrCreateNotesFolder($userId, false);
+			$notesFolder = $this->settingsService->get($userId, 'notesPath');
+			return $notesFolder;
 		} catch (NotesFolderException $e) {
 			$this->util->logger->debug("Failed to get notes folder for user $userId: " . $e->getMessage());
 			return null;
 		}
-		return $userFolder->getRelativePath($nodesFolder->getPath());
 	}
 
 	public function getOrCreateNotesFolder(string $userId, bool $create = true) : Folder {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -152,22 +152,18 @@ class SettingsService {
 		$settings = $this->getSettingsFromDB($uid);
 		// use default for empty settings
 		$toBeSaved = false;
-		$toSaveNotesPath = false;
 		foreach ($this->attrs as $name => $attr) {
 			if (!property_exists($settings, $name)) {
 				$defaultValue = $attr['default'];
 				if (is_callable($defaultValue)) {
 					$settings->{$name} = $defaultValue($uid);
 					$toBeSaved = $saveInitial;
-					if ($name === 'notesPath') {
-						$toSaveNotesPath = true;
-					}
 				} else {
 					$settings->{$name} = $defaultValue;
 				}
 			}
 		}
-		if ($toSaveNotesPath || $toBeSaved) {
+		if ($toBeSaved) {
 			$this->set($uid, (array)$settings);
 		}
 		return $settings;
@@ -176,8 +172,8 @@ class SettingsService {
 	/**
 	 * @throws \OCP\PreConditionNotMetException
 	 */
-	public function get(string $uid, string $name) : string {
-		$settings = $this->getAll($uid);
+	public function get(string $uid, string $name, bool $saveInitial = false) : string {
+		$settings = $this->getAll($uid, $saveInitial);
 		if (property_exists($settings, $name)) {
 			return $settings->{$name};
 		} else {

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -112,6 +112,9 @@ class SettingsService {
 			if ($value !== null && array_key_exists($name, $this->attrs)) {
 				$settings[$name] = $value = $this->attrs[$name]['validate']($value);
 			}
+			if ($name === 'notesPath' && $value !== null) {
+				continue;
+			}
 			$default = is_callable($this->attrs[$name]['default']) ? $this->attrs[$name]['default']($uid) : $this->attrs[$name]['default'];
 			if (!$writeDefaults && (!array_key_exists($name, $this->attrs)
 				|| $value === null
@@ -149,18 +152,22 @@ class SettingsService {
 		$settings = $this->getSettingsFromDB($uid);
 		// use default for empty settings
 		$toBeSaved = false;
+		$toSaveNotesPath = false;
 		foreach ($this->attrs as $name => $attr) {
 			if (!property_exists($settings, $name)) {
 				$defaultValue = $attr['default'];
 				if (is_callable($defaultValue)) {
 					$settings->{$name} = $defaultValue($uid);
 					$toBeSaved = $saveInitial;
+					if ($name === 'notesPath') {
+						$toSaveNotesPath = true;
+					}
 				} else {
 					$settings->{$name} = $defaultValue;
 				}
 			}
 		}
-		if ($toBeSaved) {
+		if ($toSaveNotesPath || $toBeSaved) {
 			$this->set($uid, (array)$settings);
 		}
 		return $settings;


### PR DESCRIPTION
- Instead of calling `getOrCreateNotesFolder` which can be expensive, we just use the value in the cache `settingsService->get($userId, 'notesPath')` since we assume the result is the same
- Ensure that when `getDefaultNotesPath()` is called, the value is saved in the user settings such that we need not call it again since the function does file operations