### PR TITLE
Chore(deprecation): Switch from annotations to method attributes

### DIFF
--- a/lib/Controller/NotesApiController.php
+++ b/lib/Controller/NotesApiController.php
@@ -17,9 +17,13 @@ use OCA\Notes\Service\SettingsService;
 
 use OCP\AppFramework\ApiController;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\CORS;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\StreamResponse;
 use OCP\Files\IMimeTypeDetector;
+
 use OCP\IRequest;
 
 class NotesApiController extends ApiController {
@@ -48,10 +52,10 @@ class NotesApiController extends ApiController {
 
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function index(
 		?string $category = null,
 		string $exclude = '',
@@ -92,10 +96,11 @@ class NotesApiController extends ApiController {
 
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function get(int $id, string $exclude = '') : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id, $exclude) {
 			$exclude = explode(',', $exclude);
@@ -109,10 +114,11 @@ class NotesApiController extends ApiController {
 
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function create(
 		string $category = '',
 		string $title = '',
@@ -140,11 +146,11 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 * @deprecated this was used in API v0.2 only, use #create() instead
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function createAutoTitle(
 		string $category = '',
 		string $content = '',
@@ -158,10 +164,11 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function update(
 		int $id,
 		?string $content = null,
@@ -198,11 +205,11 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 * @deprecated this was used in API v0.2 only, use #update() instead
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function updateAutoTitle(
 		int $id,
 		?string $content = null,
@@ -222,10 +229,11 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function destroy(int $id) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id) {
 			$this->service->delete($this->helper->getUID(), $id);
@@ -234,10 +242,11 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function setSettings() : JSONResponse {
 		return $this->helper->handleErrorResponse(function () {
 			$this->settingsService->setPublic($this->helper->getUID(), $this->request->getParams());
@@ -246,19 +255,20 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function getSettings() : JSONResponse {
 		return $this->helper->handleErrorResponse(function () {
 			return $this->settingsService->getPublic($this->helper->getUID());
 		});
 	}
 	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function fail() : JSONResponse {
 		return $this->helper->handleErrorResponse(function () {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
@@ -269,11 +279,11 @@ class NotesApiController extends ApiController {
 
 	/**
 	 * With help from: https://github.com/nextcloud/cookbook
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
 	 * @return JSONResponse|StreamResponse
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function getAttachment(int $noteid, string $path): Http\Response {
 		try {
 			$targetimage = $this->service->getAttachment(
@@ -297,10 +307,11 @@ class NotesApiController extends ApiController {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @CORS
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[CORS]
+	#[NoCSRFRequired]
 	public function uploadFile(int $noteid): JSONResponse {
 		$file = $this->request->getUploadedFile('file');
 		return $this->helper->handleErrorResponse(function () use ($noteid, $file): array {

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -16,8 +16,11 @@ use OCA\Notes\Service\SettingsService;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\StreamResponse;
+
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Lock\ILock;
 use OCP\Files\Lock\ILockManager;
@@ -57,8 +60,9 @@ class NotesController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function index(int $pruneBefore = 0) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($pruneBefore) {
 			$userId = $this->helper->getUID();
@@ -105,8 +109,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function dashboard() : JSONResponse {
 		return $this->helper->handleErrorResponse(function () {
 			$maxItems = 6;
@@ -137,8 +142,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function get(int $id) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id) {
 			$note = $this->notesService->get($this->helper->getUID(), $id);
@@ -160,8 +166,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function create(string $category = '', string $content = '', string $title = '') : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($category, $content, $title) {
 			$note = $this->notesService->create($this->helper->getUID(), $title, $category);
@@ -174,8 +181,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function undo(
 		int $id,
 		string $title,
@@ -213,8 +221,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function autotitle(int $id) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id) {
 			$note = $this->notesService->get($this->helper->getUID(), $id);
@@ -231,8 +240,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function update(int $id, string $content) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id, $content) {
 			$note = $this->helper->getNoteWithETagCheck($id, $this->request);
@@ -243,8 +253,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function updateProperty(
 		int $id,
 		string $property,
@@ -308,8 +319,9 @@ class NotesController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function destroy(int $id) : JSONResponse {
 		return $this->helper->handleErrorResponse(function () use ($id) {
 			$this->notesService->delete($this->helper->getUID(), $id);
@@ -319,10 +331,10 @@ class NotesController extends Controller {
 
 	/**
 	 * With help from: https://github.com/nextcloud/cookbook
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @return JSONResponse|StreamResponse
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function getAttachment(int $noteid, string $path): Http\Response {
 		try {
 			$targetimage = $this->notesService->getAttachment(
@@ -348,8 +360,9 @@ class NotesController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
+	 *
 	 */
+	#[NoAdminRequired]
 	public function uploadFile(int $noteid): JSONResponse {
 		$file = $this->request->getUploadedFile('file');
 		return $this->helper->handleErrorResponse(function () use ($noteid, $file) {

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -19,6 +19,8 @@ use OCA\Text\Event\LoadEditor;
 use OCA\Viewer\Event\LoadViewer;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -58,10 +60,10 @@ class PageController extends Controller {
 
 
 	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @suppress PhanUndeclaredClassReference, PhanTypeMismatchArgument, PhanUndeclaredClassMethod
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function index() : TemplateResponse {
 		$devMode = !is_file(dirname(__FILE__) . '/../../js/notes-main.js');
 		$response = new TemplateResponse(
@@ -100,9 +102,10 @@ class PageController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
+	 *
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function create() : RedirectResponse {
 		$note = $this->notesService->create($this->userSession->getUser()->getUID(), '', '');
 		$note->setContent('');

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -12,6 +12,7 @@ namespace OCA\Notes\Controller;
 use OCA\Notes\Service\SettingsService;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -36,9 +37,9 @@ class SettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @throws \OCP\PreConditionNotMetException
 	 */
+	#[NoAdminRequired]
 	public function set(): JSONResponse {
 		$this->service->set(
 			$this->getUID(),
@@ -48,15 +49,15 @@ class SettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function get(): JSONResponse {
 		return new JSONResponse($this->service->getAll($this->getUID()));
 	}
 
 	/**
-	 * @NoAdminRequired
 	 */
+	#[NoAdminRequired]
 	public function migrate(): JSONResponse {
 		$this->service->delete($this->getUID(), 'editorHint');
 		return new JSONResponse();


### PR DESCRIPTION
Current annotations are deprecated and cause a lot of log messages