### PR TITLE
fix(files): replace outline plus icon with normal one

### DIFF
--- a/src/components/CreateSampleButton.vue
+++ b/src/components/CreateSampleButton.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<NcButton type="secondary" @click="onNewNote">
-		<PlusOutlineIcon slot="icon" :size="20" />
+		<Plus slot="icon" :size="20" />
 		{{ t('notes', 'Create a sample note with Markdown') }}
 	</NcButton>
 </template>
@@ -15,7 +15,7 @@ import {
 	NcButton,
 } from '@nextcloud/vue'
 
-import PlusOutlineIcon from 'vue-material-design-icons/PlusOutline.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
 
 import { createNote } from '../NotesService.js'
 import { getDefaultSampleNote, getDefaultSampleNoteTitle } from '../Util.js'
@@ -23,7 +23,7 @@ import { getDefaultSampleNote, getDefaultSampleNoteTitle } from '../Util.js'
 export default {
 	components: {
 		NcButton,
-		PlusOutlineIcon,
+		Plus,
 	},
 
 	methods: {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -26,7 +26,7 @@
 		</NcDashboardWidget>
 		<div v-if="!loading" class="buttons-footer">
 			<NcButton :href="createNoteUrl">
-				<PlusOutline slot="icon" :size="20" />
+				<Plus slot="icon" :size="20" />
 				{{ t('notes', 'New note') }}
 			</NcButton>
 		</div>
@@ -37,7 +37,7 @@
 import { NcButton, NcDashboardWidget, NcDashboardWidgetItem } from '@nextcloud/vue'
 import { generateUrl } from '@nextcloud/router'
 
-import PlusOutline from 'vue-material-design-icons/PlusOutline.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
 
 import { getDashboardData } from '../NotesService.js'
 import { categoryLabel } from '../Util.js'
@@ -49,7 +49,7 @@ export default {
 		NcButton,
 		NcDashboardWidget,
 		NcDashboardWidgetItem,
-		PlusOutline,
+		Plus,
 	},
 
 	data() {

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -12,7 +12,7 @@
 			</div>
 			<div class="feature">
 				<NcButton type="secondary" @click="onNewNote">
-					<PlusOutlineIcon slot="icon" :size="20" />
+					<Plus slot="icon" :size="20" />
 					{{ t('notes', 'New note') }}
 				</NcButton>
 			</div>
@@ -39,7 +39,7 @@ import {
 	NcButton,
 } from '@nextcloud/vue'
 
-import PlusOutlineIcon from 'vue-material-design-icons/PlusOutline.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
 
 import CreateSampleButton from './CreateSampleButton.vue'
 import HelpMobile from './HelpMobile.vue'
@@ -54,7 +54,7 @@ export default {
 		HelpMobile,
 		NcAppContent,
 		NcButton,
-		PlusOutlineIcon,
+		Plus,
 	},
 
 	methods: {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/notes/issues/1611

Before:
<img width="614" height="281" alt="Screenshot from 2025-08-12 11-20-44" src="https://github.com/user-attachments/assets/caff0625-e8d0-456b-aac6-bf9ff3d9de9d" />

After:
<img width="614" height="281" alt="Screenshot from 2025-08-12 11-25-05" src="https://github.com/user-attachments/assets/f92adc69-0598-44b8-8f2a-fa791ff96224" />

