### PR TITLE
feat: improve attachment storage for API

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -200,7 +200,7 @@ return ['routes' => [
 		'url' => '/api/{apiVersion}/attachment/{noteid}',
 		'verb' => 'GET',
 		'requirements' => [
-			'apiVersion' => '(v1.4)',
+			'apiVersion' => '(v1|v1.4)',
 			'noteid' => '\d+'
 		],
 	],
@@ -209,7 +209,7 @@ return ['routes' => [
 		'url' => '/api/{apiVersion}/attachment/{noteid}',
 		'verb' => 'POST',
 		'requirements' => [
-			'apiVersion' => '(v1.4)',
+			'apiVersion' => '(v1|v1.4)',
 			'noteid' => '\d+'
 		],
 	],

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -15,7 +15,7 @@ In this document, the Notes API major version 1 and all its minor versions are d
 |   **1.1**   | Notes 3.4 (May 2020)        | Filter "Get all notes" by category                 |
 |   **1.2**   | Notes 4.1 (June 2021)       | Preventing lost updates, read-only notes, settings |
 |   **1.3**   | Notes 4.5 (August 2022)     | Allow custom file suffixes                         |
-|   **1.4**   | Notes 4.9 (August 2025)     | Add external image api                             |
+|   **1.4**   | Notes 4.9 (August 2025)     | Add external image API                             |
 
 
 
@@ -288,7 +288,7 @@ No valid authentication credentials supplied.
 | Parameter | Type                         | Description                                |
 |:----------|:-----------------------------|:-------------------------------------------|
 | `id`      | integer, required (path)     | ID of the note to load the attachment from |
-| `path`    | string, required (request)   | Path or name of the attachment to load.    |
+| `path`    | string, required (request)   | Path of the attachment to load             |
 
 Example:
 
@@ -327,16 +327,16 @@ curl -u "user:password" \
        -F "file=@/path/to/image.png" \
        "https://yournextcloud.com/index.php/apps/notes/api/v1.4/attachment/<id>"
 
-# The post request will return the filename that was generated:
-{"filename":"d8aef2005b4f815fec8ade5388240f2c.png"}
+# The post request will return the path where the image is stored:
+{"filename":".attachments.<id>/image.png"}
 ```
 
 #### Response
 ##### 200 OK
-- **Body**: Filename in json encoded:
+- **Body**: Path in JSON encoded, example:
 ```js
 {
-    "filename": "image.jpg"
+    "filaname": ".attachments.1234/image.png"
 }
 ```
 


### PR DESCRIPTION
- Attachments are stored in note-specific folder
- Attachment filenames are retained

This mirrors the behaviour for attachments created in the web UI, bringing the following benefits:
- Attachments get deleted (edit: and moved) along with the note
- Attachments don't clutter the directory alongside the note
- Non WYSIWIG editors which consume the API provide a better experience (via filenames not being replaced by random strings)
- Consistency with web

Most of the code is based on what's used in [Text](https://github.com/nextcloud/text/).

If the API wasn't already public I would switch the name of the return element for image creation to `path` (from `filename`). As there likely isn't any project consuming the API yet this may not be a bad idea.

Addresses part of #1623.