### PR TITLE
feat(ui): adapt notes settings to new UI components

### DIFF
--- a/src/components/HelpMobile.vue
+++ b/src/components/HelpMobile.vue
@@ -5,37 +5,35 @@
 
 <template>
 	<Fragment>
-		<div class="feature icon-phone">
-			{{ t('notes', 'Install the app for your mobile phone in order to access your notes from everywhere.') }}
-		</div>
-		<div class="badge-wrapper">
-			<a target="_blank" href="https://github.com/nextcloud/notes-android">
-				{{ t('notes', 'Android app: {notes}', {notes: 'Nextcloud Notes'}) }}
-			</a>
-			<div>
-				<div class="badge">
-					<a target="_blank" href="https://play.google.com/store/apps/details?id=it.niedermann.owncloud.notes">
-						<img :src="getRoute('badge_playstore.svg')" class="appstore-badge badge-playstore-fix">
-					</a>
+		<div class="help-mobile">
+			<NcFormGroup :label="t('notes', 'Android')">
+				<div class="badge-wrapper">
+					<div>
+						<div class="badge">
+							<a target="_blank" href="https://play.google.com/store/apps/details?id=it.niedermann.owncloud.notes">
+								<img :src="getRoute('badge_playstore.svg')" class="appstore-badge badge-playstore-fix">
+							</a>
+						</div>
+						<div class="badge">
+							<a target="_blank" href="https://f-droid.org/repository/browse/?fdid=it.niedermann.owncloud.notes">
+								<img :src="getRoute('badge_fdroid.svg')" class="appstore-badge">
+							</a>
+						</div>
+					</div>
 				</div>
-				<div class="badge">
-					<a target="_blank" href="https://f-droid.org/repository/browse/?fdid=it.niedermann.owncloud.notes">
-						<img :src="getRoute('badge_fdroid.svg')" class="appstore-badge">
-					</a>
+			</NcFormGroup>
+
+			<NcFormGroup :label="t('notes', 'iPhone and iPad')">
+				<div class="badge-wrapper">
+					<div>
+						<div class="badge">
+							<a target="_blank" href="https://apps.apple.com/app/nextcloud-notes/id813973264">
+								<img :src="getRoute('badge_applestore.svg')" class="appstore-badge badge-playstore-fix">
+							</a>
+						</div>
+					</div>
 				</div>
-			</div>
-		</div>
-		<div class="badge-wrapper">
-			<a target="_blank" href="https://github.com/nextcloud/notes-ios">
-				{{ t('notes', 'iOS app: {notes}', {notes: 'Nextcloud Notes'}) }}
-			</a>
-			<div>
-				<div class="badge">
-					<a target="_blank" href="https://apps.apple.com/app/nextcloud-notes/id813973264">
-						<img :src="getRoute('badge_applestore.svg')" class="appstore-badge badge-playstore-fix">
-					</a>
-				</div>
-			</div>
+			</NcFormGroup>
 		</div>
 	</Fragment>
 </template>
@@ -44,10 +42,12 @@
 import { generateFilePath } from '@nextcloud/router'
 
 import { Fragment } from 'vue-frag'
+import { NcFormGroup } from '@nextcloud/vue'
 
 export default {
 	components: {
 		Fragment,
+		NcFormGroup,
 	},
 
 	methods: {
@@ -59,9 +59,12 @@ export default {
 
 </script>
 <style scoped>
+.help-mobile {
+	display: flex;
+	flex-direction: column;
+}
+
 .badge-wrapper {
-	margin-top: 2em;
-	margin-inline-start: 2em;
 	width: 100%;
 	clear:both;
 }


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/notes/issues/1646
Dependency updates:
 - https://github.com/nextcloud/notes/pull/1664
 - https://github.com/nextcloud/notes/pull/1663

#### 🖼️ Screenshots

| 🏚️  Before   |  🏡After                                                        |
|-------------|---------------------------------------------------------------|
| <img width="1143" height="796" alt="Screenshot from 2025-11-11 18-56-40" src="https://github.com/user-attachments/assets/5068377f-75d4-4831-8a9c-003e9a2c7eb4" /> | <img width="1143" height="796" alt="Screenshot from 2025-11-11 18-53-36" src="https://github.com/user-attachments/assets/b49d61ae-6414-432f-a31b-c4a0801ce429" /> |-------------|---------------------------------------------------------------|
| <img width="1143" height="796" alt="Screenshot from 2025-11-11 18-56-36" src="https://github.com/user-attachments/assets/b602dc95-6760-47b2-a2ce-066a8f082a7a" /> | <img width="1150" height="701" alt="Screenshot from 2025-11-11 18-53-15" src="https://github.com/user-attachments/assets/0696f785-c044-4413-a968-aedab8c8c874" /> |-------------|---------------------------------------------------------------|
| <img width="1143" height="796" alt="Screenshot from 2025-11-11 18-56-28" src="https://github.com/user-attachments/assets/8519caeb-0e68-46f6-b0f3-747a556581df" /> | 
