### PR TITLE
feat (UI): drag & drop notes to categories

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -30,6 +30,7 @@
  - Felix Nüsse <felix.nuesse@t-online.de>
  - Ferdinand Mütsch <mail@ferdinand-muetsch.de>
  - Florian Hülsmann <fh@cbix.de>
+ - Grigorij Aronov <aronovgj@gmx.net>
  - Hendrik Leppelsack <hendrik@leppelsack.de>
  - Holger Hees <holger.hees@gmail.com>
  - Holly <holly@r00t.li>

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -1,6 +1,5 @@
 <!--
   - SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
-  - SPDX-FileCopyrightText: 2025 Grigorij Aronov aronovgj@gmx.net
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 

--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -1,6 +1,5 @@
 <!--
   - SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
-  - SPDX-FileCopyrightText: 2025 Grigorij Aronov aronovgj@gmx.net
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 


### PR DESCRIPTION
**Summary**
This PR adds drag & drop support to the Notes UI so notes can be moved between categories directly.

**What changed**
- Notes are now draggable (when not read-only).
- Dropping a note onto a category in the left sidebar updates the note’s category via the existing setCategory() API call.
- Dropping a note onto “All notes” removes its category (moves it to uncategorized).
- Sidebar items show a visual highlight while a draggable note is hovered over them.

**Files touched**
- NoteItem.vue: sets drag payload (note id) on drag start.
- CategoriesList.vue: implements drag-over/drop handlers for categories and “All notes”, and hover styling.


First PR, please let me know if I messed something up.