### PR TITLE
fix(attachments): Correctly keep intended attachment extension

### DIFF
--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -260,7 +260,8 @@ class NotesService {
 		} catch (\Exception $e) {
 			$filename = uniqid();
 		}
-		$filename = $filename . '.' . explode('.', $fileDataArray['name'])[1];
+		$parts = explode('.', $fileDataArray['name']);
+		$filename .= '.' . end($parts);
 
 		if ($fileDataArray['tmp_name'] === '') {
 			throw new ImageNotWritableException();


### PR DESCRIPTION
Before:
- Disable text
- Upload an image named `hello.world.jpg`
- See new attachment `515453fc3874646175f828448a21baac.world`

After:
- Disable text
- Upload an image named `hello.world.jpg`
- See new attachment `515453fc3874646175f828448a21baac.jpg`