### PR TITLE
Use filled favorite icons and remove document icons

### DIFF
--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -23,14 +23,10 @@
 				:size="20"
 				fill-color="#E9322D"
 			/>
-			<StarOutlineIcon v-else-if="note.favorite"
+			<StarIcon v-else-if="note.favorite"
 				slot="icon"
 				:size="20"
 				fill-color="#FC0"
-			/>
-			<FileDocumentOutlineIcon v-else
-				slot="icon"
-				:size="20"
 			/>
 		</template>
 		<template v-if="isShared" #indicator>
@@ -107,10 +103,9 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcActionSeparator from '@nextcloud/vue/components/NcActionSeparator'
 import NcActionInput from '@nextcloud/vue/components/NcActionInput'
 import AlertOctagonOutlineIcon from 'vue-material-design-icons/AlertOctagonOutline.vue'
-import FileDocumentOutlineIcon from 'vue-material-design-icons/FileDocumentOutline.vue'
 import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
 import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
-import StarOutlineIcon from 'vue-material-design-icons/StarOutline.vue'
+import StarIcon from 'vue-material-design-icons/Star.vue'
 import { categoryLabel, routeIsNewNote } from '../Util.js'
 import { showError } from '@nextcloud/dialogs'
 import { setFavorite, setTitle, fetchNote, deleteNote, setCategory } from '../NotesService.js'
@@ -122,11 +117,10 @@ export default {
 
 	components: {
 		AlertOctagonOutlineIcon,
-		FileDocumentOutlineIcon,
 		FolderOutlineIcon,
 		NcActionButton,
 		NcListItem,
-		StarOutlineIcon,
+		StarIcon,
 		NcActionSeparator,
 		NcActionInput,
 		PencilOutlineIcon,
@@ -145,6 +139,7 @@ export default {
 			loading: {
 				note: false,
 				category: false,
+				favorite: false,
 			},
 			newTitle: '',
 			renaming: false,


### PR DESCRIPTION
The left‑side FileDocumentOutlineIcon is always shown but doesn't have any function, and it disappears for favorites. This is inconsistent and wastes space. This change turns that area into a visible, clickable favorite toggle, so the star state is always visible and the icon slot has a purpose.

### Changes

* Add a persistent favorite toggle button to the left of each note
* Use outline star for non‑favorites, filled star for favorites
* Remove the favorite action from the dropdown menu

### Why
Keeps the UI consistent (favorites vs non‑favorites), makes the icon slot functional, and improves discoverability of the favorite action.

This is how it would look now:

<img width="359" height="406" alt="image" src="https://github.com/user-attachments/assets/b116f5c5-663a-4a78-b97f-836879029317" />
