### PR TITLE
feat(ui): Add rename/delete category actions in the sidebar

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -92,6 +92,16 @@ return ['routes' => [
 		'verb' => 'DELETE',
 		'requirements' => ['id' => '\d+'],
 	],
+	[
+		'name' => 'notes#renameCategory',
+		'url' => '/notes/category',
+		'verb' => 'PATCH',
+	],
+	[
+		'name' => 'notes#deleteCategory',
+		'url' => '/notes/category',
+		'verb' => 'DELETE',
+	],
 
 	//////////  A T T A C H M E N T S  //////////
 

--- a/lib/Controller/NotesController.php
+++ b/lib/Controller/NotesController.php
@@ -330,6 +330,26 @@ class NotesController extends Controller {
 	}
 
 	/**
+	 *
+	 */
+	#[NoAdminRequired]
+	public function renameCategory(string $oldCategory, string $newCategory) : JSONResponse {
+		return $this->helper->handleErrorResponse(function () use ($oldCategory, $newCategory) {
+			return $this->notesService->renameCategory($this->helper->getUID(), $oldCategory, $newCategory);
+		});
+	}
+
+	/**
+	 *
+	 */
+	#[NoAdminRequired]
+	public function deleteCategory(string $category) : JSONResponse {
+		return $this->helper->handleErrorResponse(function () use ($category) {
+			return $this->notesService->deleteCategory($this->helper->getUID(), $category);
+		});
+	}
+
+	/**
 	 * With help from: https://github.com/nextcloud/cookbook
 	 * @return JSONResponse|StreamResponse
 	 */

--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -60,16 +60,22 @@ class NoteUtil {
 		return $this->tagService;
 	}
 
-	public function getCategoryFolder(Folder $notesFolder, string $category) {
-		$path = $notesFolder->getPath();
-		// sanitise path
+	public function normalizeCategoryPath(string $category) : string {
 		$cats = explode('/', $category);
 		$cats = array_map([$this, 'sanitisePath'], $cats);
 		$cats = array_filter($cats, function ($str) {
 			return $str !== '';
 		});
-		$path .= '/' . implode('/', $cats);
-		return $this->getOrCreateFolder($path);
+		return implode('/', $cats);
+	}
+
+	public function getCategoryFolder(Folder $notesFolder, string $category, bool $create = true) : Folder {
+		$path = $notesFolder->getPath();
+		$normalized = $this->normalizeCategoryPath($category);
+		if ($normalized !== '') {
+			$path .= '/' . $normalized;
+		}
+		return $this->getOrCreateFolder($path, $create);
 	}
 
 	/**

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -153,6 +153,86 @@ class NotesService {
 		$this->noteUtil->deleteEmptyFolder($parent, $notesFolder);
 	}
 
+	/**
+	 * @throws NoteDoesNotExistException
+	 */
+	public function renameCategory(string $userId, string $oldCategory, string $newCategory) : array {
+		$oldCategory = $this->noteUtil->normalizeCategoryPath($oldCategory);
+		$newCategory = $this->noteUtil->normalizeCategoryPath($newCategory);
+		if ($oldCategory === '' || $newCategory === '') {
+			throw new \InvalidArgumentException('Category must not be empty');
+		}
+		if ($oldCategory === $newCategory) {
+			return [
+				'oldCategory' => $oldCategory,
+				'newCategory' => $newCategory,
+			];
+		}
+		if (str_starts_with($newCategory, $oldCategory . '/')) {
+			throw new \InvalidArgumentException('Target category must not be a descendant of source category');
+		}
+
+		$notesFolder = $this->getNotesFolder($userId);
+		try {
+			$oldFolder = $this->noteUtil->getCategoryFolder($notesFolder, $oldCategory, false);
+		} catch (NotesFolderException $e) {
+			throw new NoteDoesNotExistException();
+		}
+
+		if ($notesFolder->nodeExists($newCategory)) {
+			throw new \InvalidArgumentException('Target category already exists');
+		}
+
+		$targetParentCategory = dirname($newCategory);
+		if ($targetParentCategory === '.') {
+			$targetParentCategory = '';
+		}
+		$targetParent = $this->noteUtil->getCategoryFolder($notesFolder, $targetParentCategory, true);
+
+		$oldParent = $oldFolder->getParent();
+		$targetPath = $targetParent->getPath() . '/' . basename($newCategory);
+		$oldFolder->move($targetPath);
+		if ($oldParent instanceof Folder) {
+			$this->noteUtil->deleteEmptyFolder($oldParent, $notesFolder);
+		}
+
+		return [
+			'oldCategory' => $oldCategory,
+			'newCategory' => $newCategory,
+		];
+	}
+
+	/**
+	 * @throws NoteDoesNotExistException
+	 */
+	public function deleteCategory(string $userId, string $category) : array {
+		$category = $this->noteUtil->normalizeCategoryPath($category);
+		if ($category === '') {
+			throw new \InvalidArgumentException('Category must not be empty');
+		}
+
+		$notesFolder = $this->getNotesFolder($userId);
+		try {
+			$folder = $this->noteUtil->getCategoryFolder($notesFolder, $category, false);
+		} catch (NotesFolderException $e) {
+			// If category folder was already removed (e.g. last note moved away),
+			// treat delete as idempotent success.
+			return [
+				'category' => $category,
+			];
+		}
+
+		$parent = $folder->getParent();
+		$folder->delete();
+		if ($parent instanceof Folder) {
+			$this->noteUtil->deleteEmptyFolder($parent, $notesFolder);
+		}
+
+		return [
+			'category' => $category,
+		];
+	}
+
 	public function getTitleFromContent(string $content) : string {
 		$content = $this->noteUtil->stripMarkdown($content);
 		return $this->noteUtil->getSafeTitle($content);

--- a/playwright/e2e/basic.spec.ts
+++ b/playwright/e2e/basic.spec.ts
@@ -19,10 +19,10 @@ test.describe('Basic checks', () => {
 
 	test('Create note and type', async ({ page }) => {
 		await page.goto('/index.php/apps/notes/')
-		await page
-			.locator('#app-navigation-vue')
-			.getByRole('button', { name: 'New note' })
-			.click()
+		const newNoteButton = page.getByRole('button', { name: 'New note', exact: true })
+		await expect(newNoteButton).toBeVisible()
+		await newNoteButton.click()
+
 		const editor = new NoteEditor(page)
 		await editor.type('Hello from Playwright')
 		await expect(editor.content).toContainText('Hello from Playwright')

--- a/playwright/e2e/category-actions.spec.ts
+++ b/playwright/e2e/category-actions.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect, type Locator, type Page, type TestInfo, test } from '@playwright/test'
+import { login } from '../support/login'
+
+function appNavigation(page: Page): Locator {
+	return page.getByRole('navigation').filter({
+		has: page.getByRole('button', { name: 'New category', exact: true }),
+	}).first()
+}
+
+function newCategoryButton(page: Page): Locator {
+	return page.getByRole('button', { name: 'New category', exact: true })
+}
+
+function contentNewNoteButton(page: Page): Locator {
+	return page.getByRole('button', { name: 'New note', exact: true })
+}
+
+function notesSearchField(page: Page): Locator {
+	return page.getByRole('textbox', { name: 'Search for notes', exact: true })
+}
+
+function notesViewNewNoteButton(page: Page): Locator {
+	return notesSearchField(page)
+		.locator('xpath=ancestor::div[contains(@class, "content-list__search")][1]')
+		.getByRole('button', { name: 'New note', exact: true })
+}
+
+function navigationRow(page: Page, name: string): Locator {
+	return page.getByRole('link', { name, exact: true })
+		.locator('xpath=ancestor::li[1]')
+		.first()
+}
+
+function uniqueCategoryName(prefix: string, testInfo: TestInfo): string {
+	return `Playwright ${prefix} ${testInfo.parallelIndex}-${Date.now()}`
+}
+
+function currentNoteId(page: Page): number | null {
+	const match = page.url().match(/\/note\/(\d+)(?:\?.*)?$/)
+	return match ? Number(match[1]) : null
+}
+
+async function openNotesApp(page: Page): Promise<void> {
+	await page.goto('/index.php/apps/notes/')
+	await expect(newCategoryButton(page)).toBeVisible()
+	await expect(contentNewNoteButton(page)).toHaveCount(1)
+	await expect(contentNewNoteButton(page)).toBeVisible()
+}
+
+async function createCategory(page: Page, name: string): Promise<void> {
+	const navigation = appNavigation(page)
+
+	await newCategoryButton(page).click()
+
+	const input = navigation.getByPlaceholder('New category', { exact: true })
+	await expect(input).toBeVisible()
+	await input.fill(name)
+	await input.press('Enter')
+
+	await expect(navigationRow(page, name)).toBeVisible()
+	await expect(navigationRow(page, name)).toHaveClass(/active/)
+}
+
+async function waitForNewNoteRoute(page: Page, previousNoteId: number | null): Promise<number> {
+	await expect.poll(() => currentNoteId(page)).not.toBe(previousNoteId)
+
+	const noteId = currentNoteId(page)
+	if (noteId === null || noteId === previousNoteId) {
+		throw new Error('Expected a new note route after creating a note')
+	}
+
+	return noteId
+}
+
+async function ensureNotesView(page: Page): Promise<void> {
+	if (await notesSearchField(page).isVisible()) {
+		return
+	}
+
+	const previousNoteId = currentNoteId(page)
+	await contentNewNoteButton(page).click()
+	await waitForNewNoteRoute(page, previousNoteId)
+	await expect(notesSearchField(page)).toBeVisible()
+}
+
+async function createNoteInSelectedCategory(page: Page, category: string): Promise<number> {
+	await ensureNotesView(page)
+
+	const previousNoteId = currentNoteId(page)
+	await notesViewNewNoteButton(page).click()
+
+	const noteId = await waitForNewNoteRoute(page, previousNoteId)
+	await expect(navigationRow(page, category).locator('.app-navigation-entry__counter-wrapper')).toContainText('1')
+
+	return noteId
+}
+
+async function openCategoryActions(page: Page, category: string): Promise<void> {
+	const row = navigationRow(page, category)
+
+	await expect(row).toBeVisible()
+	await row.getByRole('button', { name: 'Actions', exact: true }).click()
+}
+
+test.describe('Category actions', () => {
+	test.beforeEach(async ({ page }) => {
+		await login(page)
+		await openNotesApp(page)
+	})
+
+	test('renames a category from the actions menu', async ({ page }, testInfo: TestInfo) => {
+		const category = uniqueCategoryName('rename', testInfo)
+		const renamedCategory = `${category} renamed`
+		const noteId = await (async () => {
+			await createCategory(page, category)
+			return createNoteInSelectedCategory(page, category)
+		})()
+
+		await openCategoryActions(page, category)
+		await page.getByRole('menuitem', { name: 'Rename category', exact: true }).click()
+
+		const renameInput = appNavigation(page).getByPlaceholder(category, { exact: true })
+		await expect(renameInput).toBeVisible()
+		await renameInput.fill(renamedCategory)
+		await renameInput.press('Enter')
+
+		await expect(navigationRow(page, renamedCategory)).toBeVisible()
+		await expect(navigationRow(page, renamedCategory)).toHaveClass(/active/)
+		await expect(navigationRow(page, renamedCategory).locator('.app-navigation-entry__counter-wrapper')).toContainText('1')
+		await expect(navigationRow(page, category)).toHaveCount(0)
+		await expect(page).toHaveURL(new RegExp(`/note/${noteId}(\\?.*)?$`))
+	})
+
+	test('deletes a category from the actions menu', async ({ page }, testInfo: TestInfo) => {
+		const category = uniqueCategoryName('delete', testInfo)
+		await createCategory(page, category)
+		const noteId = await createNoteInSelectedCategory(page, category)
+		const deletedNoteUrl = new RegExp(`/note/${noteId}(\\?.*)?$`)
+
+		await openCategoryActions(page, category)
+		await page.getByRole('menuitem', { name: 'Delete category', exact: true }).click()
+
+		const confirmationText = `Delete category "${category}" and its 1 note?`
+		await expect(page.getByText(confirmationText, { exact: true })).toBeVisible()
+
+		await page.getByRole('button', { name: 'Delete', exact: true }).click()
+
+		await expect(navigationRow(page, category)).toHaveCount(0)
+		await expect(navigationRow(page, 'All notes')).toHaveClass(/active/)
+		await expect(page).not.toHaveURL(deletedNoteUrl)
+	})
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,20 +7,17 @@
 	<EditorHint v-if="editorHint" @close="editorHint=false" />
 	<NcContent v-else app-name="notes" :content-class="{loading: loading.notes}">
 		<NcAppNavigation :class="{loading: loading.notes, 'icon-error': error}">
-			<template #search>
+			<template #list>
 				<NcAppNavigationNew
 					v-show="!loading.notes && !error"
-					:text="t('notes', 'New note')"
-					@click="onNewNote"
+					:text="t('notes', 'New category')"
+					@click="onNewCategory"
+					@dragover.native="onNewCategoryDragOver"
+					@drop.native="onNewCategoryDrop"
 				>
-					<PlusIcon slot="icon" :size="20" />
+					<FolderPlusIcon slot="icon" :size="20" />
 				</NcAppNavigationNew>
-			</template>
-
-			<template #list>
-				<CategoriesList v-show="!loading.notes"
-					v-if="numNotes"
-				/>
+				<CategoriesList v-show="!loading.notes" />
 			</template>
 
 			<template #footer>
@@ -56,16 +53,18 @@ import NcContent from '@nextcloud/vue/components/NcContent'
 import { loadState } from '@nextcloud/initial-state'
 import { showSuccess, TOAST_UNDO_TIMEOUT, TOAST_PERMANENT_TIMEOUT } from '@nextcloud/dialogs'
 import '@nextcloud/dialogs/style.css'
+import { emit } from '@nextcloud/event-bus'
 
-import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import CogIcon from 'vue-material-design-icons/CogOutline.vue'
+import FolderPlusIcon from 'vue-material-design-icons/FolderPlus.vue'
 
 import AppSettings from './components/AppSettings.vue'
 import CategoriesList from './components/CategoriesList.vue'
 import EditorHint from './components/Modal/EditorHint.vue'
 
 import { config } from './config.js'
-import { fetchNotes, noteExists, createNote, undoDeleteNote } from './NotesService.js'
+import { fetchNotes, noteExists, undoDeleteNote } from './NotesService.js'
+import { getDraggedNoteId, isNoteDrag } from './Util.js'
 import store from './store.js'
 
 export default {
@@ -81,7 +80,7 @@ export default {
 		NcAppNavigationNew,
 		NcAppNavigationItem,
 		NcContent,
-		PlusIcon,
+		FolderPlusIcon,
 	},
 
 	data() {
@@ -91,7 +90,6 @@ export default {
 			},
 			loading: {
 				notes: true,
-				create: false,
 			},
 			error: false,
 			undoNotification: null,
@@ -229,20 +227,28 @@ export default {
 			this.settingsVisible = true
 		},
 
-		onNewNote() {
-			if (this.loading.create) {
+		onNewCategory() {
+			emit('notes:category:new')
+		},
+
+		onNewCategoryDragOver(event) {
+			if (!isNoteDrag(event)) {
 				return
 			}
-			this.loading.create = true
-			createNote(store.getters.getSelectedCategory())
-				.then(note => {
-					this.routeToNote(note.id, { new: null })
-				})
-				.catch(() => {
-				})
-				.finally(() => {
-					this.loading.create = false
-				})
+			event.preventDefault()
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = 'move'
+			}
+		},
+
+		onNewCategoryDrop(event) {
+			const noteId = getDraggedNoteId(event, noteId => store.getters.getNote(noteId))
+			if (noteId === null) {
+				return
+			}
+			event.preventDefault()
+			event.stopPropagation()
+			emit('notes:category:new', { noteId })
 		},
 
 		onNoteDeleted(note) {
@@ -326,5 +332,20 @@ export default {
 	padding-bottom: 3px;
 	padding-inline-start: 3px;
 	margin: 0 3px;
+}
+
+:deep(.app-navigation__body) {
+	overflow: hidden !important;
+	flex: 0 0 auto;
+}
+
+:deep(.app-navigation__content) {
+	min-height: 0;
+}
+
+:deep(.app-navigation__list) {
+	flex: 1 1 auto;
+	min-height: 0;
+	height: auto !important;
 }
 </style>

--- a/src/NotesService.js
+++ b/src/NotesService.js
@@ -364,6 +364,32 @@ export const setCategory = (noteId, category) => {
 		})
 }
 
+export const renameCategory = (oldCategory, newCategory) => {
+	return axios
+		.patch(url('/notes/category'), null, { params: { oldCategory, newCategory } })
+		.then(response => {
+			return response.data
+		})
+		.catch(err => {
+			console.error(err)
+			handleSyncError(t('notes', 'Renaming category "{category}" has failed.', { category: oldCategory }), err)
+			throw err
+		})
+}
+
+export const deleteCategory = (category) => {
+	return axios
+		.delete(url('/notes/category'), { params: { category } })
+		.then(response => {
+			return response.data
+		})
+		.catch(err => {
+			console.error(err)
+			handleSyncError(t('notes', 'Deleting category "{category}" has failed.', { category }), err)
+			throw err
+		})
+}
+
 export const queueCommand = (noteId, type) => {
 	store.commit('addToQueue', { noteId, type })
 	_processQueue()

--- a/src/Util.js
+++ b/src/Util.js
@@ -33,6 +33,68 @@ export const routeIsNewNote = ($route) => {
 	return {}.hasOwnProperty.call($route.query, 'new')
 }
 
+export const isNoteDrag = (event) => {
+	const dt = event?.dataTransfer
+	if (!dt) {
+		return false
+	}
+
+	const types = Array.from(dt.types ?? [])
+	if (types.includes('application/x-nextcloud-notes-note-id')) {
+		return true
+	}
+	if (types.includes('text/uri-list')) {
+		return false
+	}
+	try {
+		return /^\s*\d+\s*$/.test(dt.getData('text/plain'))
+	} catch {
+		return false
+	}
+}
+
+export const getDraggedNoteId = (event, getNoteById) => {
+	const dt = event?.dataTransfer
+	if (!dt) {
+		return null
+	}
+
+	const types = Array.from(dt.types ?? [])
+	const hasCustom = types.includes('application/x-nextcloud-notes-note-id')
+	const hasUri = types.includes('text/uri-list')
+	if (!hasCustom && hasUri) {
+		return null
+	}
+
+	let raw = ''
+	if (hasCustom) {
+		try {
+			raw = dt.getData('application/x-nextcloud-notes-note-id')
+		} catch {
+			// Some browsers only allow specific mime types.
+		}
+	}
+	if (!raw) {
+		try {
+			raw = dt.getData('text/plain')
+		} catch {
+			raw = ''
+		}
+	}
+
+	const match = /^\s*(\d+)\s*$/.exec(raw)
+	const noteId = match ? Number.parseInt(match[1], 10) : Number.NaN
+	if (!Number.isFinite(noteId)) {
+		return null
+	}
+	const note = getNoteById ? getNoteById(noteId) : null
+	if (!note || note.readonly) {
+		return null
+	}
+
+	return noteId
+}
+
 export const getDefaultSampleNoteTitle = () => {
 	return t('notes', 'Sample note')
 }

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -7,11 +7,14 @@
 	<Fragment>
 		<NcAppNavigationItem
 			:name="t('notes', 'All notes')"
+			:draggable="false"
 			:class="{
 				active: selectedCategory === null,
 				'drop-over': dragOverAllNotes,
+				'category-no-actions': true,
 			}"
 			@click.prevent.stop="onSelectCategory(null)"
+			@dragstart.native="onCategoryDragStart"
 			@dragover.native="onAllNotesDragOver($event)"
 			@dragleave.native="onAllNotesDragLeave($event)"
 			@drop.native="onAllNotesDrop($event)"
@@ -28,18 +31,55 @@
 
 		<NcAppNavigationCaption :name="t('notes', 'Categories')" />
 
+		<NcAppNavigationItem
+			v-if="newCategoryDraft"
+			ref="newCategoryItem"
+			:name="''"
+			:draggable="false"
+			:icon="'icon-files'"
+			:editable="true"
+			:edit-label="t('notes', 'Rename category')"
+			:edit-placeholder="t('notes', 'New category')"
+			:force-menu="true"
+			:force-display-actions="true"
+			menu-icon="icon-more"
+			class="category-draft"
+			@click.prevent.stop
+			@dragstart.native="onCategoryDragStart"
+			@update:name="onCreateCategory"
+		>
+			<template #icon>
+				<FolderIcon :size="20" />
+			</template>
+			<template #counter>
+				<NcCounterBubble>
+					0
+				</NcCounterBubble>
+			</template>
+		</NcAppNavigationItem>
+
 		<NcAppNavigationItem v-for="category in categories"
 			:key="category.name"
 			:name="categoryTitle(category.name)"
+			:draggable="false"
 			:icon="category.name === '' ? 'icon-emptyfolder' : 'icon-files'"
+			:editable="category.name !== ''"
+			:edit-label="t('notes', 'Rename category')"
+			:edit-placeholder="category.name"
+			:force-menu="category.name !== ''"
+			:force-display-actions="category.name !== ''"
+			menu-icon="icon-more"
 			:class="{
 				active: category.name === selectedCategory,
 				'drop-over': category.name === dragOverCategory,
+				'category-no-actions': category.name === '',
 			}"
 			@click.prevent.stop="onSelectCategory(category.name)"
+			@dragstart.native="onCategoryDragStart"
 			@dragover.native="onCategoryDragOver(category.name, $event)"
 			@dragleave.native="onCategoryDragLeave(category.name, $event)"
 			@drop.native="onCategoryDrop(category.name, $event)"
+			@update:name="onRenameCategory(category.name, $event)"
 		>
 			<template #icon>
 				<FolderOutlineIcon v-if="category.name === ''" :size="20" />
@@ -50,22 +90,34 @@
 					{{ category.count }}
 				</NcCounterBubble>
 			</template>
+			<template v-if="category.name !== ''" #actions>
+				<NcActionButton
+					icon="icon-delete"
+					:close-after-click="true"
+					@click="onDeleteCategory(category.name)"
+				>
+					{{ t('notes', 'Delete category') }}
+				</NcActionButton>
+			</template>
 		</NcAppNavigationItem>
 	</Fragment>
 </template>
 
 <script>
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import NcAppNavigationCaption from '@nextcloud/vue/components/NcAppNavigationCaption'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import { Fragment } from 'vue-frag'
+import { showConfirmation } from '@nextcloud/dialogs'
+import { subscribe, unsubscribe } from '@nextcloud/event-bus'
 
 import FolderIcon from 'vue-material-design-icons/Folder.vue'
 import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
 import HistoryIcon from 'vue-material-design-icons/History.vue'
 
-import { getCategories, setCategory } from '../NotesService.js'
-import { categoryLabel } from '../Util.js'
+import { deleteCategory as deleteCategoryRequest, getCategories, renameCategory as renameCategoryRequest, setCategory } from '../NotesService.js'
+import { categoryLabel, getDraggedNoteId, isNoteDrag } from '../Util.js'
 import store from '../store.js'
 
 export default {
@@ -73,6 +125,7 @@ export default {
 
 	components: {
 		Fragment,
+		NcActionButton,
 		NcAppNavigationItem,
 		NcAppNavigationCaption,
 		NcCounterBubble,
@@ -85,6 +138,9 @@ export default {
 		return {
 			dragOverCategory: null,
 			dragOverAllNotes: false,
+			newCategoryDraft: false,
+			newCategoryMonitor: null,
+			newCategoryDropNoteId: null,
 		}
 	},
 
@@ -102,41 +158,180 @@ export default {
 		},
 	},
 
+	mounted() {
+		subscribe('notes:category:new', this.startNewCategory)
+	},
+
+	destroyed() {
+		unsubscribe('notes:category:new', this.startNewCategory)
+		this.stopNewCategoryMonitor()
+	},
+
 	methods: {
 		categoryTitle(category) {
 			return categoryLabel(category)
 		},
 
-		getDraggedNoteId(event) {
-			const dt = event?.dataTransfer
-			if (!dt) {
-				return null
+		startNewCategory(payload = {}) {
+			if (this.newCategoryDraft) {
+				return
+			}
+			this.newCategoryDropNoteId = payload?.noteId ?? null
+			this.newCategoryDraft = true
+			this.$nextTick(() => {
+				this.$refs.newCategoryItem?.handleEdit?.()
+				this.monitorNewCategoryEditing()
+			})
+		},
+
+		stopNewCategoryMonitor() {
+			if (this.newCategoryMonitor) {
+				cancelAnimationFrame(this.newCategoryMonitor)
+				this.newCategoryMonitor = null
+			}
+		},
+
+		monitorNewCategoryEditing() {
+			this.stopNewCategoryMonitor()
+			const check = () => {
+				if (!this.newCategoryDraft) {
+					this.stopNewCategoryMonitor()
+					this.newCategoryDropNoteId = null
+					return
+				}
+				const item = this.$refs.newCategoryItem
+				if (item && item.editingActive === false) {
+					this.newCategoryDraft = false
+					this.stopNewCategoryMonitor()
+					this.newCategoryDropNoteId = null
+					return
+				}
+				this.newCategoryMonitor = requestAnimationFrame(check)
+			}
+			this.newCategoryMonitor = requestAnimationFrame(check)
+		},
+
+		onCreateCategory(newCategory) {
+			const trimmed = newCategory?.trim() ?? ''
+			this.newCategoryDraft = false
+			this.stopNewCategoryMonitor()
+			const droppedNoteId = this.newCategoryDropNoteId
+			this.newCategoryDropNoteId = null
+			if (!trimmed) {
+				return
+			}
+			const exists = this.categories.some(category => category.name === trimmed)
+			if (!exists) {
+				store.commit('addLocalCategory', trimmed)
+			}
+			store.commit('setSelectedCategory', trimmed)
+			if (droppedNoteId !== null) {
+				setCategory(droppedNoteId, trimmed).catch(() => {})
+			}
+		},
+
+		getNotesInCategory(category) {
+			return store.state.notes.notes.filter(note => note.category === category || note.category.startsWith(category + '/'))
+		},
+
+		updateNotesForCategoryRename(oldCategory, newCategory) {
+			for (const note of store.state.notes.notes) {
+				if (note.category === oldCategory || note.category.startsWith(oldCategory + '/')) {
+					const updatedCategory = note.category.startsWith(oldCategory + '/')
+						? newCategory + note.category.slice(oldCategory.length)
+						: newCategory
+					store.commit('setNoteAttribute', { noteId: note.id, attribute: 'category', value: updatedCategory })
+				}
+			}
+		},
+
+		removeNotesFromCategory(categoryName) {
+			for (const note of this.getNotesInCategory(categoryName)) {
+				store.commit('removeNote', note.id)
+			}
+		},
+
+		updateSelectedCategoryForRename(oldCategory, newCategory) {
+			const selected = this.selectedCategory
+			if (selected === oldCategory) {
+				store.commit('setSelectedCategory', newCategory)
+				return
+			}
+			if (selected && selected.startsWith(oldCategory + '/')) {
+				store.commit('setSelectedCategory', newCategory + selected.slice(oldCategory.length))
+			}
+		},
+
+		clearSelectedCategoryForDelete(category) {
+			const selected = this.selectedCategory
+			if (selected === category || (selected && selected.startsWith(category + '/'))) {
+				store.commit('setSelectedCategory', null)
+			}
+		},
+
+		async onRenameCategory(category, newCategory) {
+			const trimmed = newCategory?.trim() ?? ''
+			if (!trimmed || trimmed === category) {
+				return
 			}
 
-			let raw = ''
 			try {
-				raw = dt.getData('application/x-nextcloud-notes-note-id')
+				const response = await renameCategoryRequest(category, trimmed)
+				const oldName = category
+				const newName = response?.newCategory || trimmed
+				this.updateNotesForCategoryRename(oldName, newName)
+				store.commit('renameLocalCategory', { oldCategory: oldName, newCategory: newName })
+				this.updateSelectedCategoryForRename(oldName, newName)
 			} catch {
-				// Some browsers only allow specific mime types.
+				// NotesService already shows a toast on failure.
 			}
-			if (!raw) {
-				raw = dt.getData('text/plain') || dt.getData('text/uri-list') || dt.getData('text/x-moz-url') || ''
+		},
+
+		async onDeleteCategory(categoryName) {
+			const notes = this.getNotesInCategory(categoryName)
+			if (notes.length > 0) {
+				let confirmed = false
+				const message = this.n(
+					'notes',
+					'Delete category "{category}" and its {count} note?',
+					'Delete category "{category}" and its {count} notes?',
+					notes.length,
+					{ category: this.categoryTitle(categoryName), count: notes.length },
+				)
+				try {
+					confirmed = await showConfirmation({
+						name: this.t('notes', 'Delete category'),
+						text: message,
+						labelConfirm: this.t('notes', 'Delete'),
+						labelReject: this.t('notes', 'Cancel'),
+						severity: 'warning',
+					})
+				} catch {
+					confirmed = window.confirm(message)
+				}
+				if (!confirmed) {
+					return
+				}
 			}
 
-			const match = /\/note\/(\d+)(?:[/?#\s]|$)/.exec(raw) || /^\s*(\d+)\s*$/.exec(raw)
-			const noteId = match ? Number.parseInt(match[1], 10) : Number.NaN
-			if (!Number.isFinite(noteId)) {
-				return null
+			try {
+				await deleteCategoryRequest(categoryName)
+				const deletedCategory = categoryName
+				await this.closeOpenNoteBeforeDelete(deletedCategory)
+				this.removeNotesFromCategory(deletedCategory)
+				store.commit('removeLocalCategory', deletedCategory)
+				this.clearSelectedCategoryForDelete(deletedCategory)
+			} catch {
+				// NotesService already shows a toast on failure.
 			}
-			const note = store.getters.getNote(noteId)
-			if (!note || note.readonly) {
-				return null
-			}
-
-			return noteId
 		},
 
 		onCategoryDragOver(category, event) {
+			if (!isNoteDrag(event)) {
+				this.dragOverCategory = null
+				this.dragOverAllNotes = false
+				return
+			}
 			event.preventDefault()
 			if (event.dataTransfer) {
 				event.dataTransfer.dropEffect = 'move'
@@ -146,6 +341,11 @@ export default {
 		},
 
 		onAllNotesDragOver(event) {
+			if (!isNoteDrag(event)) {
+				this.dragOverCategory = null
+				this.dragOverAllNotes = false
+				return
+			}
 			event.preventDefault()
 			if (event.dataTransfer) {
 				event.dataTransfer.dropEffect = 'move'
@@ -187,7 +387,7 @@ export default {
 			event.stopPropagation()
 
 			this.dragOverAllNotes = false
-			const noteId = this.getDraggedNoteId(event)
+			const noteId = getDraggedNoteId(event, noteId => store.getters.getNote(noteId))
 			if (noteId === null) {
 				return
 			}
@@ -204,7 +404,7 @@ export default {
 			event.preventDefault()
 			event.stopPropagation()
 
-			const noteId = this.getDraggedNoteId(event)
+			const noteId = getDraggedNoteId(event, noteId => store.getters.getNote(noteId))
 			this.dragOverCategory = null
 			this.dragOverAllNotes = false
 			if (noteId === null) {
@@ -222,6 +422,37 @@ export default {
 		onSelectCategory(category) {
 			store.commit('setSelectedCategory', category)
 		},
+
+		async closeOpenNoteBeforeDelete(categoryName) {
+			const noteId = Number.parseInt(this.$route?.params?.noteId, 10)
+			if (!Number.isFinite(noteId)) {
+				return
+			}
+			const note = store.getters.getNote(noteId)
+			if (!note) {
+				return
+			}
+			if (note.category === categoryName || note.category.startsWith(categoryName + '/')) {
+				const remainingNote = store.state.notes.notes.find(other => (
+					other.id !== noteId
+					&& other.category !== categoryName
+					&& !other.category.startsWith(categoryName + '/')
+				))
+				if (remainingNote) {
+					await this.$router.push({
+						name: 'note',
+						params: { noteId: remainingNote.id.toString() },
+					}).catch(() => {})
+				} else {
+					await this.$router.push({ name: 'welcome' }).catch(() => {})
+				}
+			}
+		},
+
+		onCategoryDragStart(event) {
+			event.preventDefault()
+			event.stopPropagation()
+		},
 	},
 }
 </script>
@@ -234,5 +465,9 @@ export default {
 	background-color: var(--color-primary-element-light) !important;
 	outline: 2px dashed var(--color-primary-element);
 	outline-offset: -2px;
+}
+
+.app-navigation-entry-wrapper.category-no-actions:deep(.app-navigation-entry__counter-wrapper) {
+	margin-inline-end: calc(var(--default-grid-baseline) * 2 + var(--default-clickable-area));
 }
 </style>

--- a/src/components/NotePlain.vue
+++ b/src/components/NotePlain.vue
@@ -311,6 +311,10 @@ export default {
 		},
 
 		refreshNote() {
+			if (!this.note) {
+				this.startRefreshTimer()
+				return
+			}
 			if (this.note.unsaved && !this.note.conflict) {
 				this.startRefreshTimer()
 				return
@@ -402,7 +406,7 @@ export default {
 		async onFileRestoreRequested(event) {
 			const { fileInfo } = event
 
-			if (fileInfo.id !== this.note.id) {
+			if (!this.note || fileInfo.id !== this.note.id) {
 				return
 			}
 
@@ -410,7 +414,7 @@ export default {
 		},
 
 		async onFileRestored(version) {
-			if (version.fileId !== this.note.id) {
+			if (!this.note || version.fileId !== this.note.id) {
 				return
 			}
 

--- a/src/components/NoteRich.vue
+++ b/src/components/NoteRich.vue
@@ -123,6 +123,9 @@ export default {
 
 		onClose(noteId) {
 			const note = store.getters.getNote(parseInt(noteId))
+			if (!note || !Number.isFinite(note.id)) {
+				return
+			}
 			store.commit('updateNote', {
 				...note,
 				unsaved: false,
@@ -130,7 +133,7 @@ export default {
 		},
 
 		fileUpdated({ fileid }) {
-			if (this.note.id === fileid) {
+			if (this.note && this.note.id === fileid) {
 				this.onEdit({ unsaved: false })
 				if (this.shouldAutotitle) {
 					queueCommand(fileid, 'autotitle')
@@ -156,7 +159,7 @@ export default {
 		async onFileRestoreRequested(event) {
 			const { fileInfo } = event
 
-			if (fileInfo.id !== this.note.id) {
+			if (!this.note || fileInfo.id !== this.note.id) {
 				return
 			}
 
@@ -164,7 +167,7 @@ export default {
 		},
 
 		async onFileRestored(version) {
-			if (version.fileId !== this.note.id) {
+			if (!this.note || version.fileId !== this.note.id) {
 				return
 			}
 

--- a/src/components/NotesView.vue
+++ b/src/components/NotesView.vue
@@ -8,6 +8,12 @@
 		<template slot="list">
 			<NcAppContentList class="content-list">
 				<div class="content-list__search">
+					<div class="content-list__actions">
+						<NcButton type="primary" :disabled="creatingNote" @click="onNewNote">
+							<PlusIcon slot="icon" :size="20" />
+							{{ t('notes', 'New note') }}
+						</NcButton>
+					</div>
 					<NcTextField
 						:value.sync="searchText"
 						:label="t('notes', 'Search for notes')"
@@ -70,6 +76,8 @@ import NotesList from './NotesList.vue'
 import NotesCaption from './NotesCaption.vue'
 import store from '../store.js'
 import Note from './Note.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
+import { createNote } from '../NotesService.js'
 
 import { ObserveVisibility } from 'vue-observe-visibility'
 
@@ -85,6 +93,7 @@ export default {
 		Note,
 		NotesList,
 		NotesCaption,
+		PlusIcon,
 	},
 
 	directives: {
@@ -106,6 +115,7 @@ export default {
 			showFirstNotesOnly: true,
 			showNote: true,
 			searchText: '',
+			creatingNote: false,
 		}
 	},
 
@@ -210,6 +220,26 @@ export default {
 			store.commit('setSelectedCategory', category)
 		},
 
+		onNewNote() {
+			if (this.creatingNote) {
+				return
+			}
+			this.creatingNote = true
+			createNote(store.getters.getSelectedCategory())
+				.then(note => {
+					this.$router.push({
+						name: 'note',
+						params: { noteId: note.id.toString() },
+						query: { new: null },
+					})
+				})
+				.catch(() => {
+				})
+				.finally(() => {
+					this.creatingNote = false
+				})
+		},
+
 		hideNote() {
 			this.showNote = false
 		},
@@ -232,7 +262,7 @@ export default {
 }
 
 .content-list__search {
-	padding: 4px;
+	padding: var(--app-navigation-padding);
 	padding-inline-start: 50px;
 	position: sticky;
 	top: 0;
@@ -242,6 +272,16 @@ export default {
 	input {
 		width: 100%;
 	}
+}
+
+.content-list__actions {
+	display: flex;
+	margin-bottom: 6px;
+}
+
+.content-list__actions :deep(.button-vue) {
+	width: 100%;
+	justify-content: center;
 }
 
 .content-list__search-more {

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -8,7 +8,7 @@
 		<div class="welcome-content">
 			<h2>{{ t('notes', 'Notes') }}</h2>
 			<div class="feature icon-add">
-				{{ t('notes', 'Start writing a note by clicking on “{newnote}” in the app navigation.', { newnote: t('notes', 'New note') }) }}
+				{{ t('notes', 'Start writing a note by clicking on “{newnote}”.', { newnote: t('notes', 'New note') }) }}
 			</div>
 			<div class="feature">
 				<NcButton type="secondary" @click="onNewNote">

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -8,6 +8,7 @@ import { copyNote } from '../Util.js'
 
 const state = {
 	categories: [],
+	localCategories: [],
 	notes: [],
 	notesIds: {},
 	selectedCategory: null,
@@ -43,20 +44,38 @@ const getters = {
 			return i
 		}
 
-		// get categories from notes
-		const categories = {}
-		for (const note of state.notes) {
-			let cat = note.category
+		function normalizeCategory(category) {
+			let cat = category
 			if (maxLevel > 0) {
 				const index = nthIndexOf(cat, '/', maxLevel)
 				if (index > 0) {
 					cat = cat.substring(0, index)
 				}
 			}
+			return cat
+		}
+
+		// get categories from notes
+		const categories = {}
+		for (const note of state.notes) {
+			const cat = normalizeCategory(note.category)
 			if (categories[cat] === undefined) {
 				categories[cat] = 1
 			} else {
 				categories[cat] += 1
+			}
+		}
+		const extraCategories = new Set([...state.categories, ...state.localCategories])
+		for (const category of extraCategories) {
+			if (!category) {
+				continue
+			}
+			const cat = normalizeCategory(category)
+			if (!cat) {
+				continue
+			}
+			if (categories[cat] === undefined) {
+				categories[cat] = 0
 			}
 		}
 		// get structured result from categories
@@ -182,6 +201,50 @@ const mutations = {
 
 	setCategories(state, categories) {
 		state.categories = categories
+		categories.forEach(category => {
+			if (category && !state.localCategories.includes(category)) {
+				state.localCategories.push(category)
+			}
+		})
+	},
+
+	addLocalCategory(state, category) {
+		if (!category || state.localCategories.includes(category) || state.categories.includes(category)) {
+			return
+		}
+		state.localCategories.push(category)
+	},
+
+	renameLocalCategory(state, { oldCategory, newCategory }) {
+		if (!oldCategory || !newCategory || oldCategory === newCategory) {
+			return
+		}
+		state.localCategories = state.localCategories.map(category => {
+			if (category === oldCategory) {
+				return newCategory
+			}
+			if (category.startsWith(oldCategory + '/')) {
+				return newCategory + category.slice(oldCategory.length)
+			}
+			return category
+		})
+		state.categories = state.categories.map(category => {
+			if (category === oldCategory) {
+				return newCategory
+			}
+			if (category.startsWith(oldCategory + '/')) {
+				return newCategory + category.slice(oldCategory.length)
+			}
+			return category
+		})
+	},
+
+	removeLocalCategory(state, category) {
+		if (!category) {
+			return
+		}
+		state.localCategories = state.localCategories.filter(cat => cat !== category && !cat.startsWith(category + '/'))
+		state.categories = state.categories.filter(cat => cat !== category && !cat.startsWith(category + '/'))
 	},
 
 	setSelectedCategory(state, category) {


### PR DESCRIPTION
This introduces a per‑category actions menu (three‑dot button) in the left navigation. 

Features:
* Added per‑category action menu (three dots) in the sidebar.
* Categories can be renamed inline directly from the menu.
* Categories can be deleted from the menu.
* Deleting a category with notes asks for confirmation.
* Deleting a category removes all notes in that category.
* New categories can be created inline (focused rename field immediately).
* Dragging a note onto “New category” creates a category and moves the note there.

Closes #1397
Closes #1120
Probably closes #1669
https://github.com/aronovgj/notes/blob/98e04a03435a384c557e6004a6c9c1cae6a672e4/src/components/NoteItem.vue#L299

This is how it would look:

<img width="640" height="543" alt="image" src="https://github.com/user-attachments/assets/83d4b011-0e40-44cf-ac67-5e5622fb33a7" />

