### PR TITLE
perf: Replace getById call with getFistNodeByid

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,7 +26,7 @@ The Notes app is a distraction free notes taking app for [Nextcloud](https://www
 	<screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
 	<dependencies>
 		<php min-version="8.0" max-version="8.4"/>
-		<nextcloud min-version="28" max-version="34"/>
+		<nextcloud min-version="30" max-version="34"/>
 	</dependencies>
 	<repair-steps>
 		<post-migration>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ The Notes app is a distraction free notes taking app for [Nextcloud](https://www
 	<repository type="git">https://github.com/nextcloud/notes.git</repository>
 	<screenshot small-thumbnail="https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes-thumbnail.jpg">https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Notes/notes.png</screenshot>
 	<dependencies>
-		<php min-version="8.0" max-version="8.4"/>
+		<php min-version="8.1" max-version="8.4"/>
 		<nextcloud min-version="30" max-version="34"/>
 	</dependencies>
 	<repair-steps>

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -290,12 +290,12 @@ class NotesService {
 	 * @throws NoteDoesNotExistException
 	 */
 	private static function getFileById(string $customExtension, Folder $folder, int $id) : File {
-		$file = $folder->getById($id);
+		$file = $folder->getFirstNodeById($id);
 
-		if (!array_key_exists(0, $file) || !($file[0] instanceof File) || !self::isNote($file[0], $customExtension)) {
+		if (!($file instanceof File) || !self::isNote($file, $customExtension)) {
 			throw new NoteDoesNotExistException();
 		}
-		return $file[0];
+		return $file;
 	}
 
 	/**

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,7 +5,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     errorBaseline="tests/psalm-baseline.xml"
-    phpVersion="8.0"
+    phpVersion="8.1"
 >
 	<stubs>
 		<file name="tests/stubs/ocp.php" preloadClasses="true"/>


### PR DESCRIPTION
We only need the first node anyway and getFirstNodeById is quite a bit faster in many cases.