### PR TITLE
fix(files): Apply HTML escaping to all user-controlled input before сoncatenating it into HTML

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -66,3 +66,9 @@ export const getDefaultSampleNote = () => {
 > ` + t('notes', 'Nextcloud, a safe home for all your data') + `
 `
 }
+
+export const escapeHtml = (str) => {
+	const element = document.createElement('div')
+	element.textContent = str
+	return element.innerHTML
+}

--- a/src/components/EditorMarkdownIt.vue
+++ b/src/components/EditorMarkdownIt.vue
@@ -11,6 +11,7 @@
 
 import MarkdownIt from 'markdown-it'
 import { generateUrl } from '@nextcloud/router'
+import { escapeHtml } from '../Util.js'
 
 export default {
 	name: 'EditorMarkdownIt',
@@ -145,7 +146,10 @@ export default {
 
 				if (download) {
 					const dlimgpath = generateUrl('svg/core/actions/download?color=ffffff')
-					return '<div class="download-file"><a href="' + path.replace(/"/g, '&quot;') + '"><div class="download-icon"><img class="download-icon-inner" src="' + dlimgpath + '">' + token.content + '</div></a></div>'
+					const tokenContent = escapeHtml(token.content)
+					return '<div class="download-file"><a href="' + path.replace(/"/g, '&quot;') + '"><div class="download-icon"><img class="download-icon-inner" '
+						+ 'src="' + dlimgpath + '">'
+						+ tokenContent + '</div></a></div>'
 				} else {
 					// pass token to default renderer.
 					return defaultRender(tokens, idx, options, env, self)


### PR DESCRIPTION
Fix for: Stored HTML Injection in Nextcloud Notes Markdown Preview via Unescaped Image Alt Text

To be done:

- All user-controlled content (including alt text) must be properly escaped according to its HTML context before being concatenated into HTML.
- Any HTML inserted via v-html should be sanitized using an allowlist-based sanitizer.

Done:

Apply HTML escaping to all user-controlled input before concatenating it into HTML