### PR TITLE
Fix undefined node array key, using folder instead

### DIFF
--- a/lib/Service/NoteUtil.php
+++ b/lib/Service/NoteUtil.php
@@ -198,7 +198,7 @@ class NoteUtil {
 		$userFolder = $this->getRoot()->getUserFolder($userId);
 		$notesPath = $this->settingsService->get($userId, 'notesPath');
 
-		['path' => $defaultPath, 'node' => $folder] = $this->settingsService->getDefaultNotesNode($userId);
+		['path' => $defaultPath, 'folder' => $folder] = $this->settingsService->getDefaultNotesNode($userId);
 		$allowShared = $notesPath !== $defaultPath;
 
 		if ($allowShared) {


### PR DESCRIPTION
Hi there,
It fixes the error on `/apps/notes/notes` API calls:
```
"message":"Undefined array key \"node\" at /var/www/nextcloud/apps/notes/lib/Service/NoteUtil.php#201"
```

Because it's the `folder` key that's defined in [SettingsService.php](https://github.com/nextcloud/notes/blob/main/lib/Service/SettingsService.php#L98) instead of `node`.

Have a nice day.

Fixes #1784