### PR TITLE
feat(ui): indicate category in "All notes" view

### DIFF
--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -14,7 +14,7 @@
 		@click="onNoteSelected(note.id)"
 		@dragstart.native="onDragStart"
 	>
-		<template #subtitle>
+		<template v-if="showCategoryTitle" #subname>
 			{{ categoryTitle }}
 		</template>
 		<template #icon>
@@ -131,6 +131,10 @@ export default {
 		note: {
 			type: Object,
 			required: true,
+		},
+		showCategoryTitle: {
+			type: Boolean,
+			default: false,
 		},
 	},
 

--- a/src/components/NotesList.vue
+++ b/src/components/NotesList.vue
@@ -6,9 +6,10 @@
 <template>
 	<ul>
 		<NoteItem v-for="note in notes"
-			:key="note.id"
+			:key="`${note.id}-${showCategoryTitle ? 'with-category-title' : 'without-category-title'}`"
 			:note="note"
 			:renaming="isRenaming(note.id)"
+			:show-category-title="showCategoryTitle"
 			@note-selected="onNoteSelected"
 			@start-renaming="onStartRenaming"
 		/>
@@ -29,6 +30,10 @@ export default {
 		notes: {
 			type: Array,
 			required: true,
+		},
+		showCategoryTitle: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/components/NotesView.vue
+++ b/src/components/NotesView.vue
@@ -26,6 +26,7 @@
 
 				<NotesList v-if="groupedNotes.length === 1"
 					:notes="groupedNotes[0].notes"
+					:show-category-title="category === null"
 					@note-selected="onNoteSelected"
 				/>
 				<template v-for="(group, idx) in groupedNotes" v-else>
@@ -40,6 +41,7 @@
 					<NotesList
 						:key="idx"
 						:notes="group.notes"
+						:show-category-title="category === null"
 						@note-selected="onNoteSelected"
 					/>
 				</template>


### PR DESCRIPTION
fixes
#1799

categories will not be displayed when a category is selected because in #1839 the current category will be indicated by a highlight

<img width="598" height="495" alt="image" src="https://github.com/user-attachments/assets/1b60cff1-09da-49c5-94ce-d25be48b7ca6" />
<img width="598" height="495" alt="image" src="https://github.com/user-attachments/assets/497191bd-15a3-4069-8d9c-91cfc8ba047f" />
