### PR TITLE
fix dead zones in clickable note area

### DIFF
--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -327,4 +327,14 @@ export default {
 		color: var(--color-primary-element-text) !important;
 	}
 }
+
+:deep(.list-item) {
+	padding: 0;
+}
+
+:deep(.list-item__anchor) {
+	box-sizing: border-box;
+	height: calc(var(--list-item-height) + 2 * var(--default-grid-baseline));
+	padding: var(--list-item-padding);
+}
 </style>


### PR DESCRIPTION
The upper and lower borders of a note are not clickable although mouse cursor shows a hand

- Make the full visible note row clickable, including the top and bottom edges
- Move the row padding onto the actual anchor so the cursor and click target match


