### PR TITLE
chore(frontend): Use OC.appswebroots instead of oc_appswebroots

### DIFF
--- a/src/components/Note.vue
+++ b/src/components/Note.vue
@@ -30,7 +30,7 @@ export default {
 
 	computed: {
 		isRichMode() {
-			return window.oc_appswebroots.text && store.state.app?.settings?.noteMode === 'rich'
+			return OC.appswebroots?.text && store.state.app?.settings?.noteMode === 'rich'
 		},
 		isPlainMode() {
 			return store.state.app?.settings?.noteMode === 'edit' || store.state.app?.settings?.noteMode === 'preview'


### PR DESCRIPTION
- Deprecated long ago (Server v17)

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
