### PR TITLE
fix(attachments): return 404 when attachment path resolves to a folder

### DIFF
--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -310,7 +310,9 @@ class NotesService {
 			}
 		}
 		$targetNode = $notesFolder->get(implode('/', $p));
-		assert($targetNode instanceof \OCP\Files\File);
+		if (!($targetNode instanceof File)) {
+			throw new NoteDoesNotExistException();
+		}
 		return $targetNode;
 	}
 

--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -316,7 +316,9 @@ class NotesService {
 			}
 		}
 		$targetNode = $notesFolder->get(implode('/', $p));
-		assert($targetNode instanceof \OCP\Files\File);
+		if (!($targetNode instanceof File)) {
+			throw new NoteDoesNotExistException();
+		}
 		return $targetNode;
 	}
 


### PR DESCRIPTION
### Summary
`NotesService::getAttachment()` resolves the requested path relative to the note's category folder and returns the node from `Folder::get()`. When that path resolves to a directory, the method relied on `assert($targetNode instanceof \OCP\Files\File)`.

### Problem
`assert()` is a **no-op in production**, where `zend.assertions=-1` is the setting shipped in `php.ini-production`. With `declare(strict_types=1)` and the `: File` return type, returning a `Folder` then raises a `TypeError`. `TypeError` is a `\Error`, **not** a `\Exception`, so it is not caught by the `catch (\Exception)` blocks in `NotesController::getAttachment()` and `NotesApiController::getAttachment()`. The request ends in **HTTP 500** instead of a clean **404**.

Reachable e.g. via `GET /apps/notes/notes/{id}/attachment?path=` on a note that has a category, because the resolved path then points at the category folder.

### Fix
Replace the assertion with an explicit `instanceof` guard that throws `NoteDoesNotExistException`. This mirrors the idiom already used in `getFileById()` in the same file, keeps the `Node` to `File` narrowing for **Psalm**, and lets the existing controller `catch (\Exception)` turn it into a **404**. No new imports required.

```php
$targetNode = $notesFolder->get(implode('/', $p));
if (!($targetNode instanceof File)) {
	throw new NoteDoesNotExistException();
}
return $targetNode;
```

### Type
**Robustness / correctness.** No security impact, no change to successful requests.

### How to test
1. Create a note inside a category, e.g. `work`.
2. Call `GET /apps/notes/notes/{id}/attachment?path=` for that note.
3. **Before:** HTTP 500. **After:** HTTP 404.

### Checklist
- [x] Follows the Nextcloud coding standard, verified with `composer cs:check`
- [x] Static analysis passes with `composer psalm`
- [x] `php -l` clean
- [ ] `Signed-off-by` line present for DCO

## 🤖 AI (if applicable)

- [x] The content of this PR was fully generated using Claude Code Fable 5.
