### PR TITLE
fix(categories): keep notes when deleting a category

### DIFF
--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -215,15 +215,35 @@ class NotesService {
 			];
 		}
 
-		$parent = $folder->getParent();
-		$folder->delete();
-		if ($parent instanceof Folder) {
-			$this->noteUtil->deleteEmptyFolder($parent, $notesFolder);
+		foreach ($this->getAll($userId)['notes'] as $note) {
+			$noteCategory = $note->getCategory();
+			if ($noteCategory === $category || str_starts_with($noteCategory, $category . '/')) {
+				$note->setCategory('');
+			}
+		}
+
+		if ($notesFolder->nodeExists($category)) {
+			$parent = $folder->getParent();
+			$this->deleteFoldersWithoutFiles($folder);
+			if ($parent instanceof Folder) {
+				$this->noteUtil->deleteEmptyFolder($parent, $notesFolder);
+			}
 		}
 
 		return [
 			'category' => $category,
 		];
+	}
+
+	private function deleteFoldersWithoutFiles(Folder $folder) : void {
+		foreach ($folder->getDirectoryListing() as $node) {
+			if ($node instanceof Folder) {
+				$this->deleteFoldersWithoutFiles($node);
+			}
+		}
+		if (count($folder->getDirectoryListing()) === 0) {
+			$folder->delete();
+		}
 	}
 
 	public function getTitleFromContent(string $content) : string {

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -245,9 +245,9 @@ export default {
 			}
 		},
 
-		removeNotesFromCategory(categoryName) {
+		moveNotesToUncategorized(categoryName) {
 			for (const note of this.getNotesInCategory(categoryName)) {
-				store.commit('removeNote', note.id)
+				store.commit('setNoteAttribute', { noteId: note.id, attribute: 'category', value: '' })
 			}
 		},
 
@@ -293,10 +293,10 @@ export default {
 				let confirmed = false
 				const message = this.n(
 					'notes',
-					'Delete category "{category}" and its {count} note?',
-					'Delete category "{category}" and its {count} notes?',
+					'Delete category "{category}"? Its {count} note will be kept and moved to "{target}".',
+					'Delete category "{category}"? Its {count} notes will be kept and moved to "{target}".',
 					notes.length,
-					{ category: this.categoryTitle(categoryName), count: notes.length },
+					{ category: this.categoryTitle(categoryName), count: notes.length, target: this.categoryTitle('') },
 				)
 				try {
 					confirmed = await showConfirmation({
@@ -316,11 +316,9 @@ export default {
 
 			try {
 				await deleteCategoryRequest(categoryName)
-				const deletedCategory = categoryName
-				await this.closeOpenNoteBeforeDelete(deletedCategory)
-				this.removeNotesFromCategory(deletedCategory)
-				store.commit('removeLocalCategory', deletedCategory)
-				this.clearSelectedCategoryForDelete(deletedCategory)
+				this.moveNotesToUncategorized(categoryName)
+				store.commit('removeLocalCategory', categoryName)
+				this.clearSelectedCategoryForDelete(categoryName)
 			} catch {
 				// NotesService already shows a toast on failure.
 			}
@@ -421,32 +419,6 @@ export default {
 
 		onSelectCategory(category) {
 			store.commit('setSelectedCategory', category)
-		},
-
-		async closeOpenNoteBeforeDelete(categoryName) {
-			const noteId = Number.parseInt(this.$route?.params?.noteId, 10)
-			if (!Number.isFinite(noteId)) {
-				return
-			}
-			const note = store.getters.getNote(noteId)
-			if (!note) {
-				return
-			}
-			if (note.category === categoryName || note.category.startsWith(categoryName + '/')) {
-				const remainingNote = store.state.notes.notes.find(other => (
-					other.id !== noteId
-					&& other.category !== categoryName
-					&& !other.category.startsWith(categoryName + '/')
-				))
-				if (remainingNote) {
-					await this.$router.push({
-						name: 'note',
-						params: { noteId: remainingNote.id.toString() },
-					}).catch(() => {})
-				} else {
-					await this.$router.push({ name: 'welcome' }).catch(() => {})
-				}
-			}
 		},
 
 		onCategoryDragStart(event) {


### PR DESCRIPTION
## Summary

Deleting a category currently deletes the category folder **including all note files inside it** — a single confirmation click can destroy many notes. This change makes "Delete category" keep the notes: they are moved to *Uncategorized* instead, and only the empty folder goes away.

## How it works

- All notes of the category (including subcategories) are moved to the notes root via the existing per-note category mechanism (`Note::setCategory('')`), so file name collisions are resolved the same way as when changing a single note's category (`Title (2).md`).
- Afterwards, only folders that contain **no files at all** are removed (new helper `deleteFoldersWithoutFiles`). Non-note files that happen to live in the category folder are never deleted.
- The confirmation dialog and the client-side store update reflect the new behavior.

## Note on the behavior change

This intentionally changes the semantics of an existing action, based on the expectation that "deleting a folder" should not silently destroy its notes. If you would rather keep the destructive delete and offer a choice (e.g. "delete notes" vs. "keep notes"), I am happy to rework this accordingly.

## Testing

- Verified end-to-end on Nextcloud 35 (dev): category folder removed, all notes kept, a colliding file name was renamed to `Name (2).md`, non-note files untouched.
- `php -l` clean, production webpack build clean.

---

## 🤖 AI (if applicable)

- [x] This pull request was prepared with assistance from Claude Code (Claude Fable 5 xhigh).
I reviewed and tested the changes myself.
