### PR TITLE
feat(notes-list): add sort toggle and improve grouping

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -69,6 +69,7 @@ class SettingsService {
 					return '.' . $out;
 				},
 			],
+			'sortMode' => $this->getListAttrs('sortMode', ['modified', 'title']),
 		];
 	}
 

--- a/src/components/NotesView.vue
+++ b/src/components/NotesView.vue
@@ -137,9 +137,14 @@ export default {
 			}
 		},
 
-		// group notes by time ("All notes") or by category (if category chosen)
+		// time grouping applies to "All notes" and to categories without subcategories
+		groupByTime() {
+			return this.category === null || this.filteredNotes.every(note => note.category === this.category)
+		},
+
+		// group notes by time or by category (if category with subcategories chosen)
 		groupedNotes() {
-			if (this.category === null) {
+			if (this.groupByTime) {
 				return this.displayedNotes.reduce((g, note) => {
 					const timeslot = this.getTimeslotFromNote(note)
 					if (g.length === 0 || g[g.length - 1].timeslot !== timeslot) {

--- a/src/components/NotesView.vue
+++ b/src/components/NotesView.vue
@@ -24,12 +24,7 @@
 					/>
 				</div>
 
-				<NotesList v-if="groupedNotes.length === 1"
-					:notes="groupedNotes[0].notes"
-					:show-category-title="category === null"
-					@note-selected="onNoteSelected"
-				/>
-				<template v-for="(group, idx) in groupedNotes" v-else>
+				<template v-for="(group, idx) in groupedNotes">
 					<NotesCaption v-if="group.category && category!==group.category"
 						:key="group.category"
 						:name="categoryToLabel(group.category)"

--- a/src/components/NotesView.vue
+++ b/src/components/NotesView.vue
@@ -14,14 +14,37 @@
 							{{ t('notes', 'New note') }}
 						</NcButton>
 					</div>
-					<NcTextField
-						:value.sync="searchText"
-						:label="t('notes', 'Search for notes')"
-						:show-trailing-button="searchText !== ''"
-						trailing-button-icon="close"
-						:trailing-button-label="t('Clear search')"
-						@trailing-button-click="searchText=''"
-					/>
+					<div class="content-list__filter">
+						<NcTextField
+							:value.sync="searchText"
+							:label="t('notes', 'Search for notes')"
+							:show-trailing-button="searchText !== ''"
+							trailing-button-icon="close"
+							:trailing-button-label="t('Clear search')"
+							@trailing-button-click="searchText=''"
+						/>
+						<NcActions class="sort-menu"
+							:aria-label="t('notes', 'Sort notes')"
+							:force-menu="true"
+						>
+							<template #icon>
+								<SortAlphabeticalAscendingIcon v-if="sortMode === 'title'" :size="20" />
+								<SortClockDescendingOutlineIcon v-else :size="20" />
+							</template>
+							<NcActionButton :close-after-click="true" @click="onSetSortMode('modified')">
+								<template #icon>
+									<SortClockDescendingOutlineIcon :size="20" />
+								</template>
+								{{ t('notes', 'Sort by modification date') }}
+							</NcActionButton>
+							<NcActionButton :close-after-click="true" @click="onSetSortMode('title')">
+								<template #icon>
+									<SortAlphabeticalAscendingIcon :size="20" />
+								</template>
+								{{ t('notes', 'Sort alphabetically') }}
+							</NcActionButton>
+						</NcActions>
+					</div>
 				</div>
 
 				<template v-for="(group, idx) in groupedNotes">
@@ -63,6 +86,8 @@
 
 <script>
 
+import NcActions from '@nextcloud/vue/components/NcActions'
+import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcAppContentList from '@nextcloud/vue/components/NcAppContentList'
 import NcAppContentDetails from '@nextcloud/vue/components/NcAppContentDetails'
@@ -74,7 +99,9 @@ import NotesCaption from './NotesCaption.vue'
 import store from '../store.js'
 import Note from './Note.vue'
 import PlusIcon from 'vue-material-design-icons/Plus.vue'
-import { createNote } from '../NotesService.js'
+import SortAlphabeticalAscendingIcon from 'vue-material-design-icons/SortAlphabeticalAscending.vue'
+import SortClockDescendingOutlineIcon from 'vue-material-design-icons/SortClockDescendingOutline.vue'
+import { createNote, setSettings } from '../NotesService.js'
 
 import { ObserveVisibility } from 'vue-observe-visibility'
 
@@ -82,6 +109,8 @@ export default {
 	name: 'NotesView',
 
 	components: {
+		NcActions,
+		NcActionButton,
 		NcAppContent,
 		NcAppContentList,
 		NcAppContentDetails,
@@ -91,6 +120,8 @@ export default {
 		NotesList,
 		NotesCaption,
 		PlusIcon,
+		SortAlphabeticalAscendingIcon,
+		SortClockDescendingOutlineIcon,
 	},
 
 	directives: {
@@ -137,13 +168,21 @@ export default {
 			}
 		},
 
+		sortMode() {
+			return store.state.app.settings.sortMode === 'title' ? 'title' : 'modified'
+		},
+
 		// time grouping applies to "All notes" and to categories without subcategories
 		groupByTime() {
 			return this.category === null || this.filteredNotes.every(note => note.category === this.category)
 		},
 
-		// group notes by time or by category (if category with subcategories chosen)
+		// group notes by time or by category (if category with subcategories chosen);
+		// the alphabetical sort mode uses a single group without captions
 		groupedNotes() {
+			if (this.sortMode === 'title') {
+				return [{ notes: this.displayedNotes }]
+			}
 			if (this.groupByTime) {
 				return this.displayedNotes.reduce((g, note) => {
 					const timeslot = this.getTimeslotFromNote(note)
@@ -222,6 +261,14 @@ export default {
 			store.commit('setSelectedCategory', category)
 		},
 
+		onSetSortMode(mode) {
+			if (this.sortMode === mode) {
+				return
+			}
+			store.state.app.settings.sortMode = mode
+			setSettings(store.state.app.settings)
+		},
+
 		onNewNote() {
 			if (this.creatingNote) {
 				return
@@ -279,6 +326,16 @@ export default {
 .content-list__actions {
 	display: flex;
 	margin-bottom: 6px;
+}
+
+.content-list__filter {
+	display: flex;
+	align-items: center;
+	gap: var(--default-grid-baseline);
+}
+
+.content-list__filter :deep(.input-field) {
+	flex: 1;
 }
 
 .content-list__actions :deep(.button-vue) {

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -128,6 +128,15 @@ const getters = {
 			return a.title.localeCompare(b.title)
 		}
 
+		function cmpTitle(a, b) {
+			return a.title.localeCompare(b.title)
+		}
+
+		if (rootState.app.settings.sortMode === 'title') {
+			notes.sort(cmpTitle)
+			return notes
+		}
+
 		const flatCategory = state.selectedCategory !== null
 			&& notes.every(note => note.category === state.selectedCategory)
 		notes.sort(state.selectedCategory === null || flatCategory ? cmpRecent : cmpCategory)

--- a/src/store/notes.js
+++ b/src/store/notes.js
@@ -128,7 +128,9 @@ const getters = {
 			return a.title.localeCompare(b.title)
 		}
 
-		notes.sort(state.selectedCategory === null ? cmpRecent : cmpCategory)
+		const flatCategory = state.selectedCategory !== null
+			&& notes.every(note => note.category === state.selectedCategory)
+		notes.sort(state.selectedCategory === null || flatCategory ? cmpRecent : cmpCategory)
 
 		return notes
 	},


### PR DESCRIPTION
## Summary

Three closely related improvements to how the notes list is grouped and ordered:

1. **Show the time caption even when there is only one group.** The list skipped the caption row whenever all notes fell into a single group, so a fresh account whose notes were all created today never saw the "Today" heading.
2. **Group flat categories by time.** Categories without subcategories showed a plain alphabetical list without any headings. They now sort and group by timeslot exactly like "All notes" (favorites first, then newest first with "Today" / "Yesterday" / … captions). Categories that contain subcategories keep the subcategory grouping.
3. **Add a sort toggle.** A small menu next to the search field switches the list between *modification date* (newest first — the previous behavior and still the default) and *alphabetical* order. The choice is stored per user as the new `sortMode` setting. Alphabetical order renders a single flat list, since time or category captions would contradict the ordering.

Fixes #613

## Testing

Automated browser tests (Playwright) on Chromium and WebKit:

- toggling to alphabetical reorders the list and removes the captions,
- the choice survives a page reload,
- switching back restores the time groups ("Today" caption) and newest-first order,
- a flat category shows the "Today" caption from its first note on.

Screenshot of the sort menu in alphabetical mode is attached:

<img width="1440" height="900" alt="shot-chromium-sort-alpha" src="https://github.com/user-attachments/assets/2e6e6666-629a-410a-8e95-c74183d79dba" />

---

## 🤖 AI (if applicable)

- [x] This pull request was prepared with assistance from Claude Code (Claude Fable 5 xhigh).
I reviewed and tested the changes myself.