### PR TITLE
feat(settings): add option to hide category names in the notes list

### DIFF
--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -69,6 +69,12 @@ class SettingsService {
 					return '.' . $out;
 				},
 			],
+			'showCategoryInList' => [
+				'default' => true,
+				'validate' => function ($value) {
+					return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+				},
+			],
 		];
 	}
 

--- a/src/components/AppSettings.vue
+++ b/src/components/AppSettings.vue
@@ -34,6 +34,14 @@
 				</NcRadioGroupButton>
 			</NcRadioGroup>
 
+			<NcCheckboxRadioSwitch
+				:checked="settings.showCategoryInList !== false"
+				type="switch"
+				@update:checked="onChangeShowCategoryInList"
+			>
+				{{ t('notes', 'Show category names in the list of all notes') }}
+			</NcCheckboxRadioSwitch>
+
 			<NcRadioGroup
 				v-model="settings.fileSuffix"
 				:label="t('notes', 'File extension')"
@@ -91,6 +99,7 @@ import NcAppSettingsSection from '@nextcloud/vue/components/NcAppSettingsSection
 import NcAppSettingsShortcutsSection from '@nextcloud/vue/components/NcAppSettingsShortcutsSection'
 import NcHotkeyList from '@nextcloud/vue/components/NcHotkeyList'
 import NcHotkey from '@nextcloud/vue/components/NcHotkey'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcRadioGroup from '@nextcloud/vue/components/NcRadioGroup'
 import NcRadioGroupButton from '@nextcloud/vue/components/NcRadioGroupButton'
 import NcFormBox from '@nextcloud/vue/components/NcFormBox'
@@ -112,6 +121,7 @@ export default {
 	name: 'AppSettings',
 
 	components: {
+		NcCheckboxRadioSwitch,
 		NcTextField,
 		NcAppSettingsDialog,
 		NcAppSettingsSection,
@@ -201,6 +211,11 @@ export default {
 			await filePicker.pick()
 
 		},
+		onChangeShowCategoryInList(checked) {
+			this.$set(this.settings, 'showCategoryInList', checked)
+			this.onChangeSettings()
+		},
+
 		onChangeSettings() {
 			this.saving = true
 			return setSettings(this.settings)

--- a/src/components/NotesView.vue
+++ b/src/components/NotesView.vue
@@ -26,7 +26,7 @@
 
 				<NotesList v-if="groupedNotes.length === 1"
 					:notes="groupedNotes[0].notes"
-					:show-category-title="category === null"
+					:show-category-title="showCategoryTitles"
 					@note-selected="onNoteSelected"
 				/>
 				<template v-for="(group, idx) in groupedNotes" v-else>
@@ -41,7 +41,7 @@
 					<NotesList
 						:key="idx"
 						:notes="group.notes"
-						:show-category-title="category === null"
+						:show-category-title="showCategoryTitles"
 						@note-selected="onNoteSelected"
 					/>
 				</template>
@@ -140,6 +140,10 @@ export default {
 			} else {
 				return this.filteredNotes
 			}
+		},
+
+		showCategoryTitles() {
+			return this.category === null && store.state.app.settings.showCategoryInList !== false
 		},
 
 		// group notes by time ("All notes") or by category (if category chosen)


### PR DESCRIPTION
## Summary

The "All notes" view shows each note's category as a second line. For people who do not use categories at all, every single row reads *Uncategorized*, which adds noise without information (see #1888).

This adds a user setting **"Show category names in the list of all notes"** (`showCategoryInList`) with a switch in the app settings.

- The **default is on**, so nothing changes for existing users.
- Turning it off hides the category line in the "All notes" view immediately.

Fixes #1888

## Testing

Verified in the browser (Chromium and WebKit): labels are shown by default, the switch hides and restores them live without a reload, and the choice is persisted per user.

---

## 🤖 AI (if applicable)

- [x] This pull request was prepared with assistance from Claude Code (Claude Fable 5).
I reviewed and tested the changes myself.
