### PR TITLE
fix(NoteRich): pass onLoaded as option in createEditor

### DIFF
--- a/src/components/NoteRich.vue
+++ b/src/components/NoteRich.vue
@@ -98,6 +98,9 @@ export default {
 				fileId: parseInt(this.noteId),
 				filePath: this.note.internalPath,
 				readOnly: false,
+				onLoaded: () => {
+					this.loading = false
+				},
 				onUpdate: ({ markdown }) => {
 					if (this.note) {
 						const unsaved = !!(this.note?.content && this.note.content !== markdown)
@@ -109,9 +112,6 @@ export default {
 					}
 				},
 			}))
-				.onLoaded(() => {
-					this.loading = false
-				})
 		},
 
 		onEdit(noteData = {}) {


### PR DESCRIPTION
The editor does not load properly anymore as recent Text app updates changed the usage of `onLoaded` in its [createEditor API](https://github.com/nextcloud/text/blob/main/src/createEditor.ts). It is not a chainable `.onLoaded(callback)` anymore and therefore has to be passed as option in `createEditor` here in `NoteRich.vue`.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
