### PR TITLE
➕ Move "New category" next to the categories caption

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,18 +12,7 @@
 	>
 		<NcAppNavigation :class="{loading: loading.notes, 'icon-error': error}">
 			<template #list>
-				<NcAppNavigationNew
-					v-show="!loading.notes && !error"
-					:text="t('notes', 'New category')"
-					@click="onNewCategory"
-					@dragover="onNewCategoryDragOver"
-					@drop="onNewCategoryDrop"
-				>
-					<template #icon>
-						<FolderPlusIcon :size="20" />
-					</template>
-				</NcAppNavigationNew>
-				<CategoriesList :loading="loading.notes" />
+				<CategoriesList :loading="loading.notes" :hideNewCategoryAction="!!error" />
 			</template>
 
 			<template #footer>
@@ -92,11 +81,9 @@ import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcAppNavigation from '@nextcloud/vue/components/NcAppNavigation'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
-import NcAppNavigationNew from '@nextcloud/vue/components/NcAppNavigationNew'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import NcContent from '@nextcloud/vue/components/NcContent'
 import CogIcon from 'vue-material-design-icons/CogOutline.vue'
-import FolderPlusIcon from 'vue-material-design-icons/FolderPlusOutline.vue'
 import FocusIcon from 'vue-material-design-icons/ImageFilterCenterFocusStrongOutline.vue'
 import ShareVariantOutlineIcon from 'vue-material-design-icons/ShareVariantOutline.vue'
 import AppSettings from './components/AppSettings.vue'
@@ -107,7 +94,6 @@ import { config } from './config.js'
 import logger from './Logger.js'
 import { fetchNotes, noteExists, undoDeleteNote } from './NotesService.js'
 import store from './store.js'
-import { getDraggedNoteId, isNoteDrag } from './Util.js'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -126,13 +112,11 @@ export default {
 		EditorHint,
 		NcAppContent,
 		NcAppNavigation,
-		NcAppNavigationNew,
 		NcAppNavigationItem,
 		NcButton,
 		NcContent,
 		FocusIcon,
 		NoteShareSidebar,
-		FolderPlusIcon,
 		ShareVariantOutlineIcon,
 	},
 
@@ -364,30 +348,6 @@ export default {
 			} else {
 				store.app.setZenMode(false)
 			}
-		},
-
-		onNewCategory() {
-			emit('notes:category:new')
-		},
-
-		onNewCategoryDragOver(event) {
-			if (!isNoteDrag(event)) {
-				return
-			}
-			event.preventDefault()
-			if (event.dataTransfer) {
-				event.dataTransfer.dropEffect = 'move'
-			}
-		},
-
-		onNewCategoryDrop(event) {
-			const noteId = getDraggedNoteId(event, (noteId) => store.notes.getNote(noteId))
-			if (noteId === null) {
-				return
-			}
-			event.preventDefault()
-			event.stopPropagation()
-			emit('notes:category:new', { noteId })
 		},
 
 		onNoteDeleted(note) {

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -27,7 +27,23 @@
 		</template>
 	</NcAppNavigationItem>
 
-	<NcAppNavigationCaption v-show="!loading" :name="t('notes', 'Categories')" />
+	<NcAppNavigationCaption v-show="!loading"
+		:name="t('notes', 'Categories')"
+		:inline="1"
+		:class="{ 'drop-over-caption': dragOverNewCategory }"
+		@dragover="onNewCategoryDragOver($event)"
+		@dragleave="onNewCategoryDragLeave($event)"
+		@drop="onNewCategoryDrop($event)"
+	>
+		<template #actions>
+			<NcActionButton v-if="!hideNewCategoryAction" @click="startNewCategory()">
+				<template #icon>
+					<FolderPlusIcon :size="20" />
+				</template>
+				{{ t('notes', 'New category') }}
+			</NcActionButton>
+		</template>
+	</NcAppNavigationCaption>
 
 	<NcAppNavigationItem
 		v-if="newCategoryDraft"
@@ -106,6 +122,7 @@ import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
 import DeleteIcon from 'vue-material-design-icons/Delete.vue'
 import FolderIcon from 'vue-material-design-icons/Folder.vue'
 import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
+import FolderPlusIcon from 'vue-material-design-icons/FolderPlusOutline.vue'
 import HistoryIcon from 'vue-material-design-icons/History.vue'
 import { deleteCategory as deleteCategoryRequest, getCategories, renameCategory as renameCategoryRequest, setCategory } from '../NotesService.js'
 import store from '../store.js'
@@ -122,16 +139,19 @@ export default {
 		NcCounterBubble,
 		FolderIcon,
 		FolderOutlineIcon,
+		FolderPlusIcon,
 		HistoryIcon,
 	},
 
 	props: {
 		loading: Boolean,
+		hideNewCategoryAction: Boolean,
 	},
 
 	data() {
 		return {
 			dragOverCategory: null,
+			dragOverNewCategory: false,
 			dragOverAllNotes: false,
 			newCategoryDraft: false,
 			newCategoryMonitor: null,
@@ -177,6 +197,40 @@ export default {
 				this.$refs.newCategoryItem?.handleEdit?.()
 				this.monitorNewCategoryEditing()
 			})
+		},
+
+		onNewCategoryDragOver(event) {
+			if (this.hideNewCategoryAction || !isNoteDrag(event)) {
+				return
+			}
+			event.preventDefault()
+			if (event.dataTransfer) {
+				event.dataTransfer.dropEffect = 'move'
+			}
+			this.dragOverNewCategory = true
+		},
+
+		onNewCategoryDragLeave(event) {
+			// dragleave also fires when moving onto a child element, so ignore
+			// events that are still inside the caption row
+			if (event.currentTarget?.contains(event.relatedTarget)) {
+				return
+			}
+			this.dragOverNewCategory = false
+		},
+
+		onNewCategoryDrop(event) {
+			if (this.hideNewCategoryAction) {
+				return
+			}
+			this.dragOverNewCategory = false
+			const noteId = getDraggedNoteId(event, (noteId) => store.notes.getNote(noteId))
+			if (noteId === null) {
+				return
+			}
+			event.preventDefault()
+			event.stopPropagation()
+			this.startNewCategory({ noteId })
 		},
 
 		stopNewCategoryMonitor() {
@@ -466,6 +520,14 @@ export default {
 	background-color: var(--color-primary-element) !important;
 	outline: 2px dashed var(--color-primary-element-text);
 	outline-offset: -2px;
+	border-radius: var(--border-radius-element, var(--border-radius-large));
+}
+
+.app-navigation-caption.drop-over-caption {
+	background-color: var(--color-primary-element-light) !important;
+	outline: 2px dashed var(--color-primary-element);
+	outline-offset: -2px;
+	border-radius: var(--border-radius-element, var(--border-radius-large));
 }
 
 .app-navigation-entry-wrapper.active:deep(.app-navigation-entry-link),

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -79,7 +79,6 @@
 		:editLabel="t('notes', 'Rename category')"
 		:editPlaceholder="category.name"
 		:forceMenu="category.name !== ''"
-		:forceDisplayActions="category.name !== ''"
 		:class="{
 			'drop-over': category.name === dragOverCategory,
 			'category-no-actions': category.name === '',
@@ -539,7 +538,34 @@ export default {
 	color: var(--color-primary-element-text) !important;
 }
 
-.app-navigation-entry-wrapper.category-no-actions:deep(.app-navigation-entry__counter-wrapper) {
-	margin-inline-end: calc(var(--default-grid-baseline) * 2 + var(--default-clickable-area));
+/* 22px is the counter bubble's diameter, so this centres a single-digit
+   bubble under the caption's icon. */
+.app-navigation-entry-wrapper:deep(.app-navigation-entry__utils) {
+	--counter-inset: calc((var(--default-clickable-area) - 22px) / 2);
+	position: relative;
+}
+
+.app-navigation-entry-wrapper:deep(.app-navigation-entry__utils .app-navigation-entry__counter-wrapper) {
+	margin-inline-end: var(--counter-inset);
+	transition: margin-inline-end var(--animation-quick) ease-in-out;
+}
+
+/* Out of the flow, so revealing it lets the counter animate aside instead of
+   being displaced instantly. */
+.app-navigation-entry-wrapper:deep(.app-navigation-entry__utils .action-item.app-navigation-entry__actions) {
+	position: absolute;
+	inset-inline-end: 0;
+}
+
+.app-navigation-entry-wrapper:not(.category-no-actions):deep(.app-navigation-entry:hover .app-navigation-entry__counter-wrapper),
+.app-navigation-entry-wrapper:not(.category-no-actions):deep(.app-navigation-entry:focus-within .app-navigation-entry__counter-wrapper),
+.app-navigation-entry-wrapper:not(.category-no-actions):deep(.app-navigation-entry.active .app-navigation-entry__counter-wrapper) {
+	margin-inline-end: calc(var(--counter-inset) + var(--default-clickable-area));
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.app-navigation-entry-wrapper:deep(.app-navigation-entry__utils .app-navigation-entry__counter-wrapper) {
+		transition: none;
+	}
 }
 </style>

--- a/src/components/CategoriesList.vue
+++ b/src/components/CategoriesList.vue
@@ -51,11 +51,7 @@
 		ref="newCategoryItem"
 		name=""
 		:draggable="false"
-		:editable="true"
-		:editLabel="t('notes', 'Rename category')"
 		:editPlaceholder="t('notes', 'New category')"
-		:forceMenu="true"
-		:forceDisplayActions="true"
 		class="category-draft"
 		@click.prevent.stop
 		@dragstart="onCategoryDragStart"
@@ -72,11 +68,10 @@
 	<NcAppNavigationItem v-for="category in categories"
 		v-show="!loading"
 		:key="category.name"
+		:ref="el => setCategoryItemRef(category.name, el)"
 		:name="categoryTitle(category.name)"
 		:active="category.name === selectedCategory"
 		:draggable="false"
-		:editable="category.name !== ''"
-		:editLabel="t('notes', 'Rename category')"
 		:editPlaceholder="category.name"
 		:forceMenu="category.name !== ''"
 		:class="{
@@ -100,6 +95,15 @@
 		<template v-if="category.name !== ''" #actions>
 			<NcActionButton
 				:closeAfterClick="true"
+				@click="onStartRenameCategory(category.name)"
+			>
+				<template #icon>
+					<PencilOutlineIcon :size="20" />
+				</template>
+				{{ t('notes', 'Rename category') }}
+			</NcActionButton>
+			<NcActionButton
+				:closeAfterClick="true"
 				@click="onDeleteCategory(category.name)"
 			>
 				<template #icon>
@@ -118,11 +122,12 @@ import NcActionButton from '@nextcloud/vue/components/NcActionButton'
 import NcAppNavigationCaption from '@nextcloud/vue/components/NcAppNavigationCaption'
 import NcAppNavigationItem from '@nextcloud/vue/components/NcAppNavigationItem'
 import NcCounterBubble from '@nextcloud/vue/components/NcCounterBubble'
-import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DeleteIcon from 'vue-material-design-icons/DeleteOutline.vue'
 import FolderIcon from 'vue-material-design-icons/Folder.vue'
 import FolderOutlineIcon from 'vue-material-design-icons/FolderOutline.vue'
 import FolderPlusIcon from 'vue-material-design-icons/FolderPlusOutline.vue'
 import HistoryIcon from 'vue-material-design-icons/History.vue'
+import PencilOutlineIcon from 'vue-material-design-icons/PencilOutline.vue'
 import { deleteCategory as deleteCategoryRequest, getCategories, renameCategory as renameCategoryRequest, setCategory } from '../NotesService.js'
 import store from '../store.js'
 import { categoryLabel, getDraggedNoteId, isNoteDrag } from '../Util.js'
@@ -140,6 +145,7 @@ export default {
 		FolderOutlineIcon,
 		FolderPlusIcon,
 		HistoryIcon,
+		PencilOutlineIcon,
 	},
 
 	props: {
@@ -155,6 +161,7 @@ export default {
 			newCategoryDraft: false,
 			newCategoryMonitor: null,
 			newCategoryDropNoteId: null,
+			categoryItems: {},
 		}
 	},
 
@@ -182,6 +189,18 @@ export default {
 	},
 
 	methods: {
+		setCategoryItemRef(category, el) {
+			if (el) {
+				this.categoryItems[category] = el
+			} else {
+				delete this.categoryItems[category]
+			}
+		},
+
+		onStartRenameCategory(category) {
+			this.categoryItems[category]?.handleEdit?.()
+		},
+
 		categoryTitle(category) {
 			return categoryLabel(category)
 		},


### PR DESCRIPTION
### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="3834" height="1893" alt="before" src="https://github.com/user-attachments/assets/e44a1165-bbf7-4308-aa58-0012e23940f8" />|<img width="3838" height="1900" alt="after" src="https://github.com/user-attachments/assets/fd0554bf-f9f0-425b-9475-11abce3e6518" />

The full-width NcAppNavigationNew button sat above everything else in the sidebar and drew attention away from the note list, even though creating a category is a rare action compared to picking one.

It is now an inline action on the "Categories" caption: NcActions renders a single inline action as one icon button, so it appears as a small folder-plus next to the heading, with the action text as its accessible name and tooltip. No separate overflow menu is rendered, because there are no other actions.

Dropping a note on the caption row still starts a new category containing that note, which is what the old button offered. The row rather than the icon is the drop target: it is a much larger area to aim at than a single icon, and the caption gets its own drop highlight since it is not an .app-navigation-entry and cannot reuse the existing .drop-over rule.

Both the click and the drop path now call CategoriesList.startNewCategory() directly instead of round-tripping through the notes:category:new event bus. The subscription stays in place so anything else can still trigger it.

The action is hidden while the note list is in an error state, matching the old button's `v-show="!loading.notes && !error"`; CategoriesList takes a `disabled` prop for that, since the caption itself is still rendered.

The accessible name is unchanged, so the Playwright helpers that locate the button by role and name keep working.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
