### PR TITLE
fix(categories): hide dot-prefixed folders from category list

### DIFF
--- a/lib/Service/NotesService.php
+++ b/lib/Service/NotesService.php
@@ -250,6 +250,12 @@ class NotesService {
 		$nodes = $folder->getDirectoryListing();
 		foreach ($nodes as $node) {
 			if ($node->getType() === FileInfo::TYPE_FOLDER && $node instanceof Folder) {
+				// hidden folders (e.g. the ".attachments.<id>" folders the Text
+				// editor creates for inline images) are not user-created
+				// categories and must not show up as such
+				if (str_starts_with($node->getName(), '.')) {
+					continue;
+				}
 				$subCategory = $categoryPrefix . $node->getName();
 				$data['categories'][] = $subCategory;
 				$data_sub = self::gatherNoteFiles($customExtension, $node, $subCategory . '/');


### PR DESCRIPTION
## Summary
- Skip dot-prefixed folders (e.g. Text editor `.attachments.<id>`) when gathering note categories.
- Stops hidden attachment folders from showing up as empty categories in the sidebar.

Fixes #1866

## Test plan
- [ ] Create a note with an inline image via Text so an `.attachments.*` folder exists.
- [ ] Confirm the Notes sidebar categories list does not include that folder.
- [ ] Confirm normal user categories still appear.
- [ ] `composer run cs:check` / `composer run psalm` if convenient.
