### PR TITLE
🎨 Improve note list

### DIFF
--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -14,7 +14,7 @@
 		@click="onNoteSelected(note.id)"
 		@dragstart="onDragStart"
 	>
-		<template v-if="showCategoryTitle" #subname>
+		<template v-if="showCategoryTitle && note.category" #subname>
 			{{ categoryTitle }}
 		</template>
 		<template #icon>

--- a/src/components/NoteItem.vue
+++ b/src/components/NoteItem.vue
@@ -360,6 +360,10 @@ export default {
 	padding: 0;
 }
 
+:deep(.list-item-content__subname) {
+	text-align: end;
+}
+
 :deep(.list-item__anchor) {
 	box-sizing: border-box;
 	height: calc(var(--list-item-height) + 2 * var(--default-grid-baseline));

--- a/src/components/NotesList.vue
+++ b/src/components/NotesList.vue
@@ -73,7 +73,6 @@ export default {
 
 <style lang="scss" scoped>
 .notes-list:deep(.list-item__wrapper) {
-	border-block-end: 1px solid var(--color-border);
 	box-sizing: border-box;
 	padding-block: 0;
 }


### PR DESCRIPTION
Resolves: #2003

* remove the divider line from the notes list
* hide the category in the notes lisst for notes that lack a category, don't show "uncategorized" like done at the moment
* right-align the category names in the notes list

### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="2575" height="1455" alt="Image" src="https://github.com/user-attachments/assets/21e43878-4d5f-4c7b-8238-35eb42340b80" />|<img width="2096" height="1218" alt="2026-08-31 11_02_54-Notes - Nextcloud — Mozilla Firefox" src="https://github.com/user-attachments/assets/14ef1eed-4d4e-43f1-859f-916cb4d98d4c" />

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
