### PR TITLE
fix(e2e): wait for the Notes API before running the Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -48,8 +48,8 @@ export default defineConfig({
 		url: "http://127.0.0.1:8089/index.php/apps/notes/",
 		timeout: 5 * 60 * 1000, // max. 5 minutes for creating the container
 		wait: {
-			// we wait for this line to appear in the output of the webserver until consider it done
-			stdout: /Nextcloud is now ready to use/,
+			// the start script prints this line once the Notes API answers requests
+			stdout: /Notes API is ready/,
 		},
 	},
 

--- a/playwright/start-nextcloud-server.mjs
+++ b/playwright/start-nextcloud-server.mjs
@@ -31,6 +31,35 @@ async function start() {
 	})
 }
 
+/**
+ * Poll the Notes API until it answers. The web workers cache the app config and
+ * the compiled routes in APCu for a few seconds, and `occ app:enable` runs in a
+ * separate process that cannot invalidate them, so requests sent right after
+ * enabling the app are answered with 404 until those caches expire.
+ *
+ * @param {string} ip Host and port the Nextcloud container is reachable at
+ */
+async function waitOnNotesApi(ip) {
+	const user = process.env.NC_USER ?? 'admin'
+	const password = process.env.NC_PASS ?? 'admin'
+	const headers = { Authorization: `Basic ${btoa(`${user}:${password}`)}` }
+	const deadline = Date.now() + 60_000
+
+	process.stdout.write('\nWaiting for the Notes API… ⏳\n')
+	while (true) {
+		const status = await fetch(`http://${ip}/index.php/apps/notes/api/v1/settings`, { headers })
+			.then((response) => response.status, () => 0)
+		if (status === 200) {
+			break
+		}
+		if (Date.now() > deadline) {
+			throw new Error(`Notes API is not reachable, last status: ${status}`)
+		}
+		await new Promise((resolve) => setTimeout(resolve, 500))
+	}
+	process.stdout.write('└─ Notes API is ready 🎉\n')
+}
+
 async function stop() {
 	process.stderr.write('Stopping Nextcloud server…\n')
 	await stopNextcloud()
@@ -44,6 +73,7 @@ process.on('SIGINT', stop)
 const ip = await start()
 await waitOnNextcloud(ip)
 await configureNextcloud(['notes'])
+await waitOnNotesApi(ip)
 
 // Idle to wait for shutdown
 while (true) {


### PR DESCRIPTION
## ☑️ Summary

The Playwright job fails intermittently on pull requests that do not touch the tests, always the same way: the first tests in `attachment-api.spec.ts` receive Nextcloud's HTML 404 page when they create a note, and a retry a few seconds later succeeds. Recent examples are #1972 ([run](https://github.com/nextcloud/notes/actions/runs/34456945152/job/102805438388)), #2024, #2023 and the `fast-uri` bump on 2026-09-02.

### Root cause

`@nextcloud/e2e-test-server` prints `Nextcloud is now ready to use` immediately after `occ app:enable notes`, and the Playwright config waits for exactly that line before starting the suite. At that moment the Apache workers do not serve the app yet. `OC\AppConfig` keeps the app config, including which apps are enabled, in the local APCu cache for three seconds, and `occ` runs in a separate process that cannot invalidate it. A request landing in that window compiles a route collection without the notes routes, so it is answered with the generic 404 page.

Measured against the e2e container by disabling the app, priming a request and enabling it again:

| run | first 200 after enabling |
| --- | --- |
| 1 | 1967 ms |
| 2 | 508 ms |
| 3 | 1970 ms |

Whether a CI run fails depends only on where its first request lands in that cycle, which is why the failure moves between unrelated pull requests. The trace of the failing job confirms the response is the server's 404 page, not a Notes error.

### Fix

The start script polls the Notes API after configuring Nextcloud and prints its own readiness line once the endpoint answers 200. The Playwright config waits for that line instead of the library's.

The `url` option is kept so `reuseExistingServer` keeps working for local runs. It is a sound gate on its own: on the container used here an unknown app route answers 404, which Playwright does not accept as ready, while a live one answers 401, which it does. It was never reached before because the stdout line won the race.

### Testing

- `npx eslint` passes on both changed files.
- Full local Playwright run against Docker: 34 passed, and the tests only start after `Notes API is ready` is printed.
- Opened as a draft to observe the Playwright job in CI.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI